### PR TITLE
docs: add moduledocs and examples to all 21 command builder modules

### DIFF
--- a/lib/redis/commands/bitmap.ex
+++ b/lib/redis/commands/bitmap.ex
@@ -1,14 +1,68 @@
 defmodule Redis.Commands.Bitmap do
   @moduledoc """
   Command builders for Redis bitmap operations.
+
+  Provides pure functions that build command lists for manipulating individual bits
+  within string values. Supports setting and reading bits (SETBIT/GETBIT), counting
+  set bits (BITCOUNT), finding bit positions (BITPOS), bitwise operations between
+  keys (BITOP), and the compound BITFIELD command for multi-bit integer access.
+  Each function returns a plain list of strings suitable for passing to
+  `Redis.command/2` or `Redis.pipeline/2`.
+
+  These functions contain no connection or networking logic -- they only construct
+  the Redis protocol command as a list.
+
+  ## Examples
+
+  Set and read individual bits (useful for feature flags or presence tracking):
+
+      iex> Redis.Commands.Bitmap.setbit("user:1:features", 7, 1)
+      ["SETBIT", "user:1:features", "7", "1"]
+      iex> Redis.Commands.Bitmap.getbit("user:1:features", 7)
+      ["GETBIT", "user:1:features", "7"]
+
+  Count the number of set bits in a key:
+
+      iex> Redis.Commands.Bitmap.bitcount("user:1:features")
+      ["BITCOUNT", "user:1:features"]
+
+  Use BITFIELD for multi-bit integer operations:
+
+      iex> Redis.Commands.Bitmap.bitfield("mykey", ["GET", "u8", "0", "SET", "u8", "0", "100"])
+      ["BITFIELD", "mykey", "GET", "u8", "0", "SET", "u8", "0", "100"]
   """
 
   @spec getbit(String.t(), integer()) :: [String.t()]
   def getbit(key, offset), do: ["GETBIT", key, to_string(offset)]
 
+  @doc """
+  Builds a SETBIT command to set or clear the bit at the given offset.
+
+  The value must be 0 or 1. Returns the command list; Redis will respond with the
+  original bit value at that offset.
+
+  ## Example
+
+      iex> Redis.Commands.Bitmap.setbit("flags", 7, 1)
+      ["SETBIT", "flags", "7", "1"]
+  """
   @spec setbit(String.t(), integer(), integer()) :: [String.t()]
   def setbit(key, offset, value), do: ["SETBIT", key, to_string(offset), to_string(value)]
 
+  @doc """
+  Builds a BITCOUNT command to count the number of set bits (population count).
+
+  Without options, counts all bits in the value. Use `:start` and `:end` to limit
+  the range, and `:byte` or `:bit` to specify whether the range is in bytes or bits.
+
+  ## Examples
+
+      iex> Redis.Commands.Bitmap.bitcount("flags")
+      ["BITCOUNT", "flags"]
+
+      iex> Redis.Commands.Bitmap.bitcount("flags", start: 0, end: 10, byte: true)
+      ["BITCOUNT", "flags", "0", "10", "BYTE"]
+  """
   @spec bitcount(String.t(), keyword()) :: [String.t()]
   def bitcount(key, opts \\ []) do
     cmd = ["BITCOUNT", key]
@@ -34,6 +88,17 @@ defmodule Redis.Commands.Bitmap do
     ["BITOP", String.upcase(operation), destkey | keys]
   end
 
+  @doc """
+  Builds a BITFIELD command for multi-bit integer operations on a string key.
+
+  The subcommands list contains the raw BITFIELD subcommand tokens (GET, SET,
+  INCRBY, OVERFLOW) as a flat list of strings.
+
+  ## Example
+
+      iex> Redis.Commands.Bitmap.bitfield("counters", ["SET", "u8", "0", "42"])
+      ["BITFIELD", "counters", "SET", "u8", "0", "42"]
+  """
   @spec bitfield(String.t(), [String.t()]) :: [String.t()]
   def bitfield(key, subcommands) when is_list(subcommands) do
     ["BITFIELD", key | subcommands]

--- a/lib/redis/commands/bloom.ex
+++ b/lib/redis/commands/bloom.ex
@@ -1,11 +1,41 @@
 defmodule Redis.Commands.Bloom do
   @moduledoc """
-  Command builders for Redis Bloom filter operations.
+  Command builders for Redis Bloom filter (`BF.*`) operations.
+
+  A Bloom filter is a space-efficient probabilistic data structure used for set
+  membership testing. It can tell you with certainty that an item is **not** in
+  the set, but positive membership responses may be false positives. The
+  trade-off is dramatic memory savings compared to storing every element.
+
+  All functions in this module are pure and return a command list (a list of
+  strings) suitable for passing to `Redis.command/2` or `Redis.pipeline/2`.
+
+  ## Examples
+
+      # Reserve a filter allowing 0.01 (1%) error rate for up to 1000 items
+      Redis.command(conn, Bloom.reserve("emails", 0.01, 1000))
+
+      # Add an item and check membership
+      Redis.pipeline(conn, [
+        Bloom.add("emails", "alice@example.com"),
+        Bloom.exists("emails", "alice@example.com")
+      ])
   """
 
+  @doc """
+  Adds an item to a Bloom filter, creating the filter if it does not exist.
+
+  Returns 1 if the item was newly added, 0 if it may have existed already.
+  """
   @spec add(String.t(), String.t()) :: [String.t()]
   def add(key, item), do: ["BF.ADD", key, item]
 
+  @doc """
+  Checks whether an item may exist in a Bloom filter.
+
+  Returns 1 if the item may exist (possible false positive), 0 if the item
+  definitely does not exist.
+  """
   @spec exists(String.t(), String.t()) :: [String.t()]
   def exists(key, item), do: ["BF.EXISTS", key, item]
 
@@ -15,6 +45,13 @@ defmodule Redis.Commands.Bloom do
   @spec mexists(String.t(), [String.t()]) :: [String.t()]
   def mexists(key, items) when is_list(items), do: ["BF.MEXISTS", key | items]
 
+  @doc """
+  Creates an empty Bloom filter with the given `error_rate` and `capacity`.
+
+  The error rate is the desired probability of false positives (e.g. 0.01 for
+  1%). The capacity is the expected number of unique items. Optional keyword
+  arguments: `:expansion` (growth factor) and `:nonscaling` (disable scaling).
+  """
   @spec reserve(String.t(), float(), non_neg_integer(), keyword()) :: [String.t()]
   def reserve(key, error_rate, capacity, opts \\ []) do
     cmd = ["BF.RESERVE", key, to_string(error_rate), to_string(capacity)]

--- a/lib/redis/commands/cms.ex
+++ b/lib/redis/commands/cms.ex
@@ -1,18 +1,53 @@
 defmodule Redis.Commands.CMS do
   @moduledoc """
-  Command builders for Redis Count-Min Sketch operations.
+  Command builders for Redis Count-Min Sketch (`CMS.*`) operations.
+
+  A Count-Min Sketch is a probabilistic data structure for estimating the
+  frequency of items in a data stream. It uses a fixed-size matrix of counters
+  addressed by multiple hash functions. Frequency estimates may **overcount**
+  but will never **undercount**, making it useful for approximate frequency
+  queries where a small positive bias is acceptable.
+
+  All functions in this module are pure and return a command list (a list of
+  strings) suitable for passing to `Redis.command/2` or `Redis.pipeline/2`.
+
+  ## Examples
+
+      # Initialize by exact dimensions (width x depth)
+      Redis.command(conn, CMS.initbydim("clicks", 2000, 5))
+
+      # Increment counts and query frequencies
+      Redis.pipeline(conn, [
+        CMS.incrby("clicks", [{"page_a", 3}, {"page_b", 1}]),
+        CMS.query("clicks", ["page_a", "page_b"])
+      ])
   """
 
+  @doc """
+  Initializes a Count-Min Sketch with the given `width` and `depth`.
+
+  The `width` controls accuracy (more columns = less overcounting) and
+  `depth` controls confidence (more rows = lower probability of large error).
+  """
   @spec initbydim(String.t(), non_neg_integer(), non_neg_integer()) :: [String.t()]
   def initbydim(key, width, depth) do
     ["CMS.INITBYDIM", key, to_string(width), to_string(depth)]
   end
 
+  @doc """
+  Initializes a Count-Min Sketch with a desired `error` rate and `probability`
+  of exceeding that error. This is a convenience alternative to `initbydim/3`
+  that lets Redis choose the matrix dimensions.
+  """
   @spec initbyprob(String.t(), float(), float()) :: [String.t()]
   def initbyprob(key, error, probability) do
     ["CMS.INITBYPROB", key, to_string(error), to_string(probability)]
   end
 
+  @doc """
+  Increments the count of one or more items. Each element in the list is a
+  `{item, increment}` tuple.
+  """
   @spec incrby(String.t(), [{String.t(), integer()}]) :: [String.t()]
   def incrby(key, item_increments) when is_list(item_increments) do
     [

--- a/lib/redis/commands/cuckoo.ex
+++ b/lib/redis/commands/cuckoo.ex
@@ -1,17 +1,54 @@
 defmodule Redis.Commands.Cuckoo do
   @moduledoc """
-  Command builders for Redis Cuckoo filter operations.
+  Command builders for Redis Cuckoo filter (`CF.*`) operations.
+
+  A Cuckoo filter is a probabilistic data structure similar to a Bloom filter
+  but with two key advantages: it supports **deletion** of previously added
+  items, and it can report approximate item counts. Like Bloom filters, Cuckoo
+  filters may return false positives but never false negatives. The trade-off
+  is slightly higher memory usage per element compared to Bloom filters.
+
+  All functions in this module are pure and return a command list (a list of
+  strings) suitable for passing to `Redis.command/2` or `Redis.pipeline/2`.
+
+  ## Examples
+
+      # Reserve a Cuckoo filter for up to 10_000 items
+      Redis.command(conn, Cuckoo.reserve("users", 10_000))
+
+      # Add, check, and delete an item
+      Redis.pipeline(conn, [
+        Cuckoo.add("users", "alice"),
+        Cuckoo.exists("users", "alice"),
+        Cuckoo.del("users", "alice")
+      ])
   """
 
+  @doc """
+  Adds an item to a Cuckoo filter, creating the filter if it does not exist.
+  """
   @spec add(String.t(), String.t()) :: [String.t()]
   def add(key, item), do: ["CF.ADD", key, item]
 
   @spec addnx(String.t(), String.t()) :: [String.t()]
   def addnx(key, item), do: ["CF.ADDNX", key, item]
 
+  @doc """
+  Checks whether an item may exist in a Cuckoo filter.
+
+  Returns 1 if the item may exist (possible false positive), 0 if the item
+  definitely does not exist.
+  """
   @spec exists(String.t(), String.t()) :: [String.t()]
   def exists(key, item), do: ["CF.EXISTS", key, item]
 
+  @doc """
+  Deletes an item from a Cuckoo filter.
+
+  This is the main advantage over Bloom filters. Returns 1 if the item was
+  found and deleted, 0 otherwise. Deleting an item that was not added may
+  cause false negatives for other items.
+  """
   @spec del(String.t(), String.t()) :: [String.t()]
   def del(key, item), do: ["CF.DEL", key, item]
 

--- a/lib/redis/commands/geo.ex
+++ b/lib/redis/commands/geo.ex
@@ -1,8 +1,47 @@
 defmodule Redis.Commands.Geo do
   @moduledoc """
   Command builders for Redis geospatial operations.
+
+  Provides pure functions that build command lists for storing, querying, and
+  measuring geographic coordinates using Redis sorted sets. Supports adding
+  members with longitude/latitude (GEOADD), searching by radius or bounding box
+  (GEOSEARCH), computing distances (GEODIST), and retrieving positions (GEOPOS).
+  Each function returns a plain list of strings suitable for passing to
+  `Redis.command/2` or `Redis.pipeline/2`.
+
+  These functions contain no connection or networking logic -- they only construct
+  the Redis protocol command as a list.
+
+  ## Examples
+
+  Add geographic coordinates for several locations:
+
+      iex> Redis.Commands.Geo.geoadd("restaurants", [{-122.4194, 37.7749, "San Francisco"}, {-73.9857, 40.7484, "New York"}])
+      ["GEOADD", "restaurants", "-122.4194", "37.7749", "San Francisco", "-73.9857", "40.7484", "New York"]
+
+  Search for members within a radius of a given point:
+
+      iex> Redis.Commands.Geo.geosearch("restaurants", fromlonlat: {-122.4194, 37.7749}, byradius: {50, "km"}, asc: true)
+      ["GEOSEARCH", "restaurants", "FROMLONLAT", "-122.4194", "37.7749", "BYRADIUS", "50", "km", "ASC"]
+
+  Compute the distance between two members:
+
+      iex> Redis.Commands.Geo.geodist("restaurants", "San Francisco", "New York", "mi")
+      ["GEODIST", "restaurants", "San Francisco", "New York", "mi"]
   """
 
+  @doc """
+  Builds a GEOADD command to add members with longitude/latitude to a geo set.
+
+  Each member is a `{longitude, latitude, name}` tuple. Supports `:nx` (only add
+  new members), `:xx` (only update existing), and `:ch` (return count of changed
+  elements).
+
+  ## Example
+
+      iex> Redis.Commands.Geo.geoadd("places", [{13.361389, 38.115556, "Palermo"}], ch: true)
+      ["GEOADD", "places", "CH", "13.361389", "38.115556", "Palermo"]
+  """
   @spec geoadd(String.t(), [{float(), float(), String.t()}], keyword()) :: [String.t()]
   def geoadd(key, members, opts \\ []) when is_list(members) do
     cmd = ["GEOADD", key]
@@ -14,6 +53,19 @@ defmodule Redis.Commands.Geo do
       Enum.flat_map(members, fn {lng, lat, member} -> [to_string(lng), to_string(lat), member] end)
   end
 
+  @doc """
+  Builds a GEODIST command to compute the distance between two members.
+
+  The optional unit argument can be "m" (meters, default), "km", "mi", or "ft".
+
+  ## Examples
+
+      iex> Redis.Commands.Geo.geodist("places", "Palermo", "Catania")
+      ["GEODIST", "places", "Palermo", "Catania"]
+
+      iex> Redis.Commands.Geo.geodist("places", "Palermo", "Catania", "km")
+      ["GEODIST", "places", "Palermo", "Catania", "km"]
+  """
   @spec geodist(String.t(), String.t(), String.t(), String.t() | nil) :: [String.t()]
   def geodist(key, member1, member2, unit \\ nil) do
     cmd = ["GEODIST", key, member1, member2]
@@ -23,9 +75,30 @@ defmodule Redis.Commands.Geo do
   @spec geohash(String.t(), [String.t()]) :: [String.t()]
   def geohash(key, members) when is_list(members), do: ["GEOHASH", key | members]
 
+  @doc """
+  Builds a GEOPOS command to retrieve the longitude/latitude of one or more members.
+
+  ## Example
+
+      iex> Redis.Commands.Geo.geopos("places", ["Palermo", "Catania"])
+      ["GEOPOS", "places", "Palermo", "Catania"]
+  """
   @spec geopos(String.t(), [String.t()]) :: [String.t()]
   def geopos(key, members) when is_list(members), do: ["GEOPOS", key | members]
 
+  @doc """
+  Builds a GEOSEARCH command to query members within a geographic area.
+
+  Requires an origin (`:fromlonlat` or `:frommember`) and a shape (`:byradius`
+  or `:bybox`). Supports ordering (`:asc`/`:desc`), result limiting (`:count`),
+  and optional coordinate/distance/hash output (`:withcoord`, `:withdist`,
+  `:withhash`).
+
+  ## Example
+
+      iex> Redis.Commands.Geo.geosearch("places", frommember: "Palermo", byradius: {200, "km"}, count: 5, withcoord: true)
+      ["GEOSEARCH", "places", "FROMMEMBER", "Palermo", "BYRADIUS", "200", "km", "COUNT", "5", "WITHCOORD"]
+  """
   @spec geosearch(String.t(), keyword()) :: [String.t()]
   def geosearch(key, opts \\ []) do
     ["GEOSEARCH", key]

--- a/lib/redis/commands/hash.ex
+++ b/lib/redis/commands/hash.ex
@@ -2,26 +2,63 @@ defmodule Redis.Commands.Hash do
   @moduledoc """
   Command builders for Redis hash operations.
 
-  ## TODO (Phase 2)
+  This module provides pure functions that return Redis command lists for
+  hash data type operations, including setting and retrieving fields,
+  atomic field increments, and hash scanning. All functions return a list
+  of strings suitable for use with `Redis.command/2` or `Redis.pipeline/2`.
 
-  HDEL, HEXISTS, HGET, HGETALL, HINCRBY, HINCRBYFLOAT, HKEYS,
-  HLEN, HMGET, HMSET, HRANDFIELD, HSCAN, HSET, HSETNX, HVALS
+  ## Examples
+
+      # HSET with multiple fields at once
+      iex> Redis.Commands.Hash.hset("user:1", [{"name", "Alice"}, {"age", "30"}])
+      ["HSET", "user:1", "name", "Alice", "age", "30"]
+
+      # Retrieve all fields and values
+      iex> Redis.Commands.Hash.hgetall("user:1")
+      ["HGETALL", "user:1"]
+
+      # Atomically increment a numeric field
+      iex> Redis.Commands.Hash.hincrby("user:1", "login_count", 1)
+      ["HINCRBY", "user:1", "login_count", "1"]
   """
 
+  @doc """
+  Builds an HGET command to retrieve the value of a single `field` in the
+  hash stored at `key`. Returns `nil` when the field or key does not exist.
+  """
   @spec hget(String.t(), String.t()) :: [String.t()]
   def hget(key, field), do: ["HGET", key, field]
 
+  @doc """
+  Builds an HSET command to set one or more field-value pairs in the hash
+  stored at `key`. Accepts a list of `{field, value}` tuples. Fields that
+  already exist are overwritten.
+  """
   @spec hset(String.t(), [{String.t(), String.t()}]) :: [String.t()]
   def hset(key, pairs) when is_list(pairs) do
     ["HSET", key | Enum.flat_map(pairs, fn {f, v} -> [f, to_string(v)] end)]
   end
 
+  @doc """
+  Builds an HGETALL command to retrieve all fields and values in the hash
+  stored at `key`. The result from Redis is a flat list alternating between
+  field names and their values.
+  """
   @spec hgetall(String.t()) :: [String.t()]
   def hgetall(key), do: ["HGETALL", key]
 
+  @doc """
+  Builds an HDEL command to remove one or more `fields` from the hash at `key`.
+  Returns the number of fields that were removed.
+  """
   @spec hdel(String.t(), [String.t()]) :: [String.t()]
   def hdel(key, fields) when is_list(fields), do: ["HDEL", key | fields]
 
+  @doc """
+  Builds an HINCRBY command to atomically increment the integer value of
+  `field` in the hash at `key` by `amount`. If the field does not exist,
+  it is initialized to 0 before incrementing.
+  """
   @spec hincrby(String.t(), String.t(), integer()) :: [String.t()]
   def hincrby(key, field, amount), do: ["HINCRBY", key, field, to_string(amount)]
 
@@ -51,6 +88,16 @@ defmodule Redis.Commands.Hash do
     cmd
   end
 
+  @doc """
+  Builds an HSCAN command to incrementally iterate over fields in the hash
+  at `key`. Start with `cursor` 0 and use the cursor returned by Redis in
+  subsequent calls until it returns 0.
+
+  ## Options
+
+    * `:match` - glob-style pattern to filter field names
+    * `:count` - hint for how many elements to return per call
+  """
   @spec hscan(String.t(), integer(), keyword()) :: [String.t()]
   def hscan(key, cursor, opts \\ []) do
     cmd = ["HSCAN", key, to_string(cursor)]

--- a/lib/redis/commands/hyperloglog.ex
+++ b/lib/redis/commands/hyperloglog.ex
@@ -1,14 +1,71 @@
 defmodule Redis.Commands.HyperLogLog do
   @moduledoc """
-  Command builders for Redis HyperLogLog operations.
+  Command builders for Redis HyperLogLog probabilistic data structure.
+
+  Provides pure functions that build command lists for HyperLogLog operations,
+  which allow approximate cardinality estimation (counting unique elements) using
+  a fixed amount of memory regardless of the number of elements. Supports adding
+  elements (PFADD), estimating cardinality (PFCOUNT), and merging multiple
+  HyperLogLog keys (PFMERGE). Each function returns a plain list of strings
+  suitable for passing to `Redis.command/2` or `Redis.pipeline/2`.
+
+  These functions contain no connection or networking logic -- they only construct
+  the Redis protocol command as a list.
+
+  ## Examples
+
+  Track unique visitors and estimate the total count:
+
+      iex> Redis.Commands.HyperLogLog.pfadd("visitors:2026-04-01", ["user:1", "user:2", "user:3"])
+      ["PFADD", "visitors:2026-04-01", "user:1", "user:2", "user:3"]
+      iex> Redis.Commands.HyperLogLog.pfcount(["visitors:2026-04-01"])
+      ["PFCOUNT", "visitors:2026-04-01"]
+
+  Merge multiple days into a weekly count:
+
+      iex> Redis.Commands.HyperLogLog.pfmerge("visitors:week:14", ["visitors:2026-04-01", "visitors:2026-04-02"])
+      ["PFMERGE", "visitors:week:14", "visitors:2026-04-01", "visitors:2026-04-02"]
   """
 
+  @doc """
+  Builds a PFADD command to add elements to a HyperLogLog key.
+
+  Redis returns 1 if the internal representation was altered (i.e., the estimated
+  cardinality changed), 0 otherwise.
+
+  ## Example
+
+      iex> Redis.Commands.HyperLogLog.pfadd("unique_ips", ["10.0.0.1", "10.0.0.2"])
+      ["PFADD", "unique_ips", "10.0.0.1", "10.0.0.2"]
+  """
   @spec pfadd(String.t(), [String.t()]) :: [String.t()]
   def pfadd(key, elements) when is_list(elements), do: ["PFADD", key | elements]
 
+  @doc """
+  Builds a PFCOUNT command to estimate the cardinality of one or more HyperLogLog keys.
+
+  When given multiple keys, Redis returns the approximate cardinality of the union
+  of all the keys without modifying them.
+
+  ## Example
+
+      iex> Redis.Commands.HyperLogLog.pfcount(["unique_ips"])
+      ["PFCOUNT", "unique_ips"]
+  """
   @spec pfcount([String.t()]) :: [String.t()]
   def pfcount(keys) when is_list(keys), do: ["PFCOUNT" | keys]
 
+  @doc """
+  Builds a PFMERGE command to merge multiple HyperLogLog keys into a destination key.
+
+  The resulting key will contain the union of all source keys. This is useful for
+  computing aggregate cardinality over time periods or shards.
+
+  ## Example
+
+      iex> Redis.Commands.HyperLogLog.pfmerge("all_ips", ["ips:shard1", "ips:shard2"])
+      ["PFMERGE", "all_ips", "ips:shard1", "ips:shard2"]
+  """
   @spec pfmerge(String.t(), [String.t()]) :: [String.t()]
   def pfmerge(destkey, sourcekeys) when is_list(sourcekeys) do
     ["PFMERGE", destkey | sourcekeys]

--- a/lib/redis/commands/json.ex
+++ b/lib/redis/commands/json.ex
@@ -1,19 +1,28 @@
 defmodule Redis.Commands.JSON do
   @moduledoc """
-  Command builders for Redis JSON operations (Redis 8+ / RedisJSON).
+  Command builders for RedisJSON operations (Redis 8+ / RedisJSON module).
 
-  All path arguments default to `"$"` (root). Values are automatically
-  encoded to JSON strings via `JSON.encode!/1`.
+  Provides pure functions for storing, retrieving, and manipulating JSON
+  documents inside Redis. Supports the full JSON.* command set including
+  object, array, string, and numeric operations.
 
-  ## Usage
+  All path arguments default to `"$"` (JSONPath root). Values passed to
+  mutating functions are automatically encoded via `JSON.encode!/1` unless
+  the `raw: true` option is given.
 
-      # Raw command building
-      Redis.Commands.JSON.set("user:1", %{name: "Alice", age: 30})
-      #=> ["JSON.SET", "user:1", "$", ~s({"name":"Alice","age":30})]
+  Every function returns a command list for use with `Redis.command/2` or
+  `Redis.pipeline/2`.
 
-      # With connection
-      Redis.command(conn, JSON.set("doc", %{x: 1}))
-      Redis.command(conn, JSON.get("doc"))
+  ## Examples
+
+      # Store a JSON document
+      Redis.command(conn, JSON.set("user:1", %{name: "Alice", age: 30}))
+
+      # Read specific paths from a document
+      Redis.command(conn, JSON.get("user:1", paths: ["$.name", "$.age"]))
+
+      # Append elements to a nested array
+      Redis.command(conn, JSON.arrappend("user:1", ["reading", "hiking"], "$.hobbies"))
   """
 
   @root "$"

--- a/lib/redis/commands/key.ex
+++ b/lib/redis/commands/key.ex
@@ -1,21 +1,66 @@
 defmodule Redis.Commands.Key do
   @moduledoc """
-  Command builders for Redis key operations.
+  Command builders for Redis key management operations.
 
-  Pure functions that return command lists — no connection logic.
+  Provides pure functions that build command lists for key-level operations such as
+  deleting keys, setting expiration, querying TTL, scanning the keyspace, checking
+  existence, renaming, and copying keys. Each function returns a plain list of
+  strings suitable for passing to `Redis.command/2` or `Redis.pipeline/2`.
 
-  ## TODO (Phase 2)
+  These functions contain no connection or networking logic -- they only construct
+  the Redis protocol command as a list.
 
-  DEL, EXISTS, EXPIRE, EXPIREAT, KEYS, PERSIST, PEXPIRE, PTTL,
-  RANDOMKEY, RENAME, RENAMENX, SCAN, SORT, TTL, TYPE, UNLINK, WAIT
+  ## Examples
+
+  Delete one or more keys:
+
+      iex> Redis.Commands.Key.del(["session:1", "session:2"])
+      ["DEL", "session:1", "session:2"]
+
+  Set a TTL and then read it back:
+
+      iex> Redis.Commands.Key.expire("session:1", 300)
+      ["EXPIRE", "session:1", "300"]
+      iex> Redis.Commands.Key.ttl("session:1")
+      ["TTL", "session:1"]
+
+  Scan the keyspace with a pattern and count hint:
+
+      iex> Redis.Commands.Key.scan(0, match: "user:*", count: 100)
+      ["SCAN", "0", "MATCH", "user:*", "COUNT", "100"]
   """
 
+  @doc """
+  Builds a DEL command to remove one or more keys.
+
+  Returns the command list for deleting the given keys. Redis returns the number
+  of keys that were removed.
+
+  ## Example
+
+      iex> Redis.Commands.Key.del(["key1", "key2"])
+      ["DEL", "key1", "key2"]
+  """
   @spec del([String.t()]) :: [String.t()]
   def del(keys) when is_list(keys), do: ["DEL" | keys]
 
   @spec exists([String.t()]) :: [String.t()]
   def exists(keys) when is_list(keys), do: ["EXISTS" | keys]
 
+  @doc """
+  Builds an EXPIRE command to set a key's time-to-live in seconds.
+
+  Supports the `:nx` option to set the expiry only when the key has no existing
+  expiry.
+
+  ## Examples
+
+      iex> Redis.Commands.Key.expire("session:1", 3600)
+      ["EXPIRE", "session:1", "3600"]
+
+      iex> Redis.Commands.Key.expire("session:1", 3600, nx: true)
+      ["EXPIRE", "session:1", "3600", "NX"]
+  """
   @spec expire(String.t(), integer(), keyword()) :: [String.t()]
   def expire(key, seconds, opts \\ []) do
     cmd = ["EXPIRE", key, to_string(seconds)]
@@ -28,6 +73,20 @@ defmodule Redis.Commands.Key do
   @spec type(String.t()) :: [String.t()]
   def type(key), do: ["TYPE", key]
 
+  @doc """
+  Builds a SCAN command to incrementally iterate over the keyspace.
+
+  Accepts options for pattern matching (`:match`), iteration count hint
+  (`:count`), and key type filtering (`:type`).
+
+  ## Examples
+
+      iex> Redis.Commands.Key.scan(0)
+      ["SCAN", "0"]
+
+      iex> Redis.Commands.Key.scan(0, match: "user:*", count: 50, type: "string")
+      ["SCAN", "0", "MATCH", "user:*", "COUNT", "50", "TYPE", "string"]
+  """
   @spec scan(integer(), keyword()) :: [String.t()]
   def scan(cursor, opts \\ []) do
     cmd = ["SCAN", to_string(cursor)]
@@ -93,6 +152,14 @@ defmodule Redis.Commands.Key do
   @spec randomkey() :: [String.t()]
   def randomkey, do: ["RANDOMKEY"]
 
+  @doc """
+  Builds a RENAME command to rename a key.
+
+  ## Example
+
+      iex> Redis.Commands.Key.rename("old_key", "new_key")
+      ["RENAME", "old_key", "new_key"]
+  """
   @spec rename(String.t(), String.t()) :: [String.t()]
   def rename(key, newkey), do: ["RENAME", key, newkey]
 

--- a/lib/redis/commands/list.ex
+++ b/lib/redis/commands/list.ex
@@ -2,35 +2,86 @@ defmodule Redis.Commands.List do
   @moduledoc """
   Command builders for Redis list operations.
 
-  ## TODO (Phase 2)
+  This module provides pure functions that return Redis command lists for
+  list data type operations, including pushing/popping elements, range
+  queries, blocking pops, and atomic moves between lists. All functions
+  return a list of strings suitable for use with `Redis.command/2` or
+  `Redis.pipeline/2`.
 
-  BLMOVE, BLPOP, BRPOP, LINDEX, LINSERT, LLEN, LMOVE, LPOP,
-  LPOS, LPUSH, LPUSHX, LRANGE, LREM, LSET, LTRIM, RPOP,
-  RPUSH, RPUSHX
+  ## Examples
+
+      # Push multiple elements to the head and tail of a list
+      iex> Redis.Commands.List.lpush("queue", ["c", "b", "a"])
+      ["LPUSH", "queue", "c", "b", "a"]
+
+      iex> Redis.Commands.List.rpush("queue", ["x", "y"])
+      ["RPUSH", "queue", "x", "y"]
+
+      # Retrieve a range of elements (0-based, inclusive)
+      iex> Redis.Commands.List.lrange("queue", 0, -1)
+      ["LRANGE", "queue", "0", "-1"]
+
+      # Blocking pop with a 5-second timeout
+      iex> Redis.Commands.List.blpop(["queue1", "queue2"], 5)
+      ["BLPOP", "queue1", "queue2", "5"]
+
+      # Atomically move an element between lists
+      iex> Redis.Commands.List.lmove("src", "dst", "LEFT", "RIGHT")
+      ["LMOVE", "src", "dst", "LEFT", "RIGHT"]
   """
 
+  @doc """
+  Builds an LPUSH command to prepend one or more `values` to the head of
+  the list at `key`. Elements are inserted one after another from left to
+  right, so the last element in the list will be the first in the resulting
+  list. Returns the length of the list after the push.
+  """
   @spec lpush(String.t(), [String.t()]) :: [String.t()]
   def lpush(key, values) when is_list(values), do: ["LPUSH", key | values]
 
+  @doc """
+  Builds an RPUSH command to append one or more `values` to the tail of
+  the list at `key`. Returns the length of the list after the push.
+  """
   @spec rpush(String.t(), [String.t()]) :: [String.t()]
   def rpush(key, values) when is_list(values), do: ["RPUSH", key | values]
 
+  @doc """
+  Builds an LPOP command to remove and return the first element of the list
+  at `key`. When `count` is provided, removes and returns up to `count`
+  elements from the head.
+  """
   @spec lpop(String.t(), non_neg_integer() | nil) :: [String.t()]
   def lpop(key, count \\ nil) do
     if count, do: ["LPOP", key, to_string(count)], else: ["LPOP", key]
   end
 
+  @doc """
+  Builds an RPOP command to remove and return the last element of the list
+  at `key`. When `count` is provided, removes and returns up to `count`
+  elements from the tail.
+  """
   @spec rpop(String.t(), non_neg_integer() | nil) :: [String.t()]
   def rpop(key, count \\ nil) do
     if count, do: ["RPOP", key, to_string(count)], else: ["RPOP", key]
   end
 
+  @doc """
+  Builds an LRANGE command to return elements from index `start` to `stop`
+  (inclusive) in the list at `key`. Indices are 0-based; negative indices
+  count from the end (-1 is the last element).
+  """
   @spec lrange(String.t(), integer(), integer()) :: [String.t()]
   def lrange(key, start, stop), do: ["LRANGE", key, to_string(start), to_string(stop)]
 
   @spec llen(String.t()) :: [String.t()]
   def llen(key), do: ["LLEN", key]
 
+  @doc """
+  Builds a BLPOP command to perform a blocking pop from the head of one or
+  more lists. The call blocks for up to `timeout` seconds until an element
+  becomes available. A timeout of 0 blocks indefinitely.
+  """
   @spec blpop([String.t()], integer()) :: [String.t()]
   def blpop(keys, timeout) when is_list(keys), do: ["BLPOP" | keys] ++ [to_string(timeout)]
 
@@ -51,6 +102,11 @@ defmodule Redis.Commands.List do
     ["LINSERT", key, pos, pivot, element]
   end
 
+  @doc """
+  Builds an LMOVE command to atomically pop an element from `source` and
+  push it to `destination`. Use `wherefrom` and `whereto` ("LEFT" or
+  "RIGHT") to control which end of each list is used.
+  """
   @spec lmove(String.t(), String.t(), String.t(), String.t()) :: [String.t()]
   def lmove(source, destination, wherefrom, whereto) do
     ["LMOVE", source, destination, wherefrom, whereto]

--- a/lib/redis/commands/pubsub_cmds.ex
+++ b/lib/redis/commands/pubsub_cmds.ex
@@ -1,20 +1,73 @@
 defmodule Redis.Commands.PubSub do
   @moduledoc """
-  Command builders for Redis pub/sub operations usable from regular connections.
+  Command builders for Redis Pub/Sub introspection and publishing.
+
+  This module provides pure functions that return Redis command lists for
+  publishing messages and inspecting Pub/Sub state. These commands can be
+  issued over a regular connection (unlike SUBSCRIBE/PSUBSCRIBE which require
+  a dedicated Pub/Sub connection).
+
+  All functions return a command list (e.g. `["PUBLISH", "chan", "msg"]`) and
+  are intended for use with `Redis.command/2` or `Redis.pipeline/2`.
+
+  ## Examples
+
+      # Publish a message to a channel
+      Redis.command(conn, PubSub.publish("events", "user_signed_up"))
+
+      # List active channels matching a pattern
+      Redis.command(conn, PubSub.pubsub_channels(pattern: "events:*"))
+
+      # Get subscriber counts for specific channels
+      Redis.command(conn, PubSub.pubsub_numsub(["events:login", "events:logout"]))
+
+      # Publish to a shard channel (Redis 7+)
+      Redis.command(conn, PubSub.spublish("orders:{us-east}", "new_order"))
   """
 
+  @doc """
+  PUBLISH -- post a message to a channel.
+
+  Returns the number of clients that received the message.
+
+      PubSub.publish("notifications", "hello")
+      #=> ["PUBLISH", "notifications", "hello"]
+  """
   @spec publish(String.t(), String.t()) :: [String.t()]
   def publish(channel, message), do: ["PUBLISH", channel, message]
 
+  @doc """
+  SPUBLISH -- post a message to a shard channel (Redis 7+).
+
+  Similar to `publish/2` but targets shard channels, which are routed only
+  to the cluster node owning the shard.
+
+      PubSub.spublish("orders:{us-east}", "new_order")
+      #=> ["SPUBLISH", "orders:{us-east}", "new_order"]
+  """
   @spec spublish(String.t(), String.t()) :: [String.t()]
   def spublish(shardchannel, message), do: ["SPUBLISH", shardchannel, message]
 
+  @doc """
+  PUBSUB CHANNELS -- list active channels, optionally filtered by a glob pattern.
+
+      PubSub.pubsub_channels()                        #=> ["PUBSUB", "CHANNELS"]
+      PubSub.pubsub_channels(pattern: "events:*")     #=> ["PUBSUB", "CHANNELS", "events:*"]
+  """
   @spec pubsub_channels(keyword()) :: [String.t()]
   def pubsub_channels(opts \\ []) do
     cmd = ["PUBSUB", "CHANNELS"]
     if opts[:pattern], do: cmd ++ [opts[:pattern]], else: cmd
   end
 
+  @doc """
+  PUBSUB NUMSUB -- get the subscriber count for the given channels.
+
+  Returns a flat list of channel/count pairs.
+
+      PubSub.pubsub_numsub(["ch1", "ch2"])
+      #=> ["PUBSUB", "NUMSUB", "ch1", "ch2"]
+  """
   @spec pubsub_numsub([String.t()]) :: [String.t()]
   def pubsub_numsub(channels \\ []) when is_list(channels) do
     ["PUBSUB", "NUMSUB" | channels]

--- a/lib/redis/commands/script.ex
+++ b/lib/redis/commands/script.ex
@@ -1,13 +1,48 @@
 defmodule Redis.Commands.Script do
   @moduledoc """
-  Command builders for Redis scripting and function operations.
+  Command builders for Redis Lua scripting and Redis Functions.
+
+  This module covers two related subsystems:
+
+    * **Lua scripting** -- `EVAL`, `EVALSHA`, and `SCRIPT *` commands for
+      running ad-hoc Lua scripts on the server.
+    * **Redis Functions** (Redis 7+) -- `FCALL`, `FCALL_RO`, and `FUNCTION *`
+      commands for managing and invoking persistent, named functions.
+
+  All functions are pure and return a command list for use with
+  `Redis.command/2` or `Redis.pipeline/2`.
+
+  ## Examples
+
+      # Evaluate a Lua script that increments a key by a given amount
+      Redis.command(conn, Script.eval("return redis.call('INCRBY', KEYS[1], ARGV[1])", ["counter"], ["5"]))
+
+      # Call a previously loaded function
+      Redis.command(conn, Script.fcall("myfunc", ["key1"], ["arg1", "arg2"]))
+
+      # Load a function library (Redis 7+)
+      Redis.command(conn, Script.function_load("#!lua name=mylib\\nredis.register_function('myfunc', function(keys, args) return keys[1] end)"))
   """
 
+  @doc """
+  EVAL -- evaluate a Lua script on the server.
+
+  The `keys` list is passed as KEYS and `args` as ARGV inside the script.
+  The number of keys is computed automatically.
+
+      Script.eval("return redis.call('SET', KEYS[1], ARGV[1])", ["mykey"], ["myval"])
+      #=> ["EVAL", "return redis.call('SET', KEYS[1], ARGV[1])", "1", "mykey", "myval"]
+  """
   @spec eval(String.t(), [String.t()], [String.t()]) :: [String.t()]
   def eval(script, keys \\ [], args \\ []) do
     ["EVAL", script, to_string(length(keys))] ++ keys ++ args
   end
 
+  @doc """
+  EVALSHA -- evaluate a cached Lua script by its SHA1 digest.
+
+  Use `script_load/1` first to cache the script and obtain its SHA1.
+  """
   @spec evalsha(String.t(), [String.t()], [String.t()]) :: [String.t()]
   def evalsha(sha1, keys \\ [], args \\ []) do
     ["EVALSHA", sha1, to_string(length(keys))] ++ keys ++ args
@@ -37,6 +72,14 @@ defmodule Redis.Commands.Script do
   @spec script_load(String.t()) :: [String.t()]
   def script_load(script), do: ["SCRIPT", "LOAD", script]
 
+  @doc """
+  FUNCTION LOAD -- load a function library into Redis (Redis 7+).
+
+  Pass `replace: true` to overwrite an existing library with the same name.
+
+      Script.function_load("#!lua name=mylib\\nredis.register_function('myfunc', function(keys, args) return 'ok' end)")
+      Script.function_load(code, replace: true)
+  """
   @spec function_load(String.t(), keyword()) :: [String.t()]
   def function_load(function_code, opts \\ []) do
     cmd = ["FUNCTION", "LOAD"]
@@ -73,6 +116,15 @@ defmodule Redis.Commands.Script do
   @spec function_stats() :: [String.t()]
   def function_stats, do: ["FUNCTION", "STATS"]
 
+  @doc """
+  FCALL -- invoke a Redis Function by name (Redis 7+).
+
+  Like `eval/3`, the `keys` and `args` lists map to KEYS and ARGV inside
+  the function body.
+
+      Script.fcall("myfunc", ["key1"], ["arg1"])
+      #=> ["FCALL", "myfunc", "1", "key1", "arg1"]
+  """
   @spec fcall(String.t(), [String.t()], [String.t()]) :: [String.t()]
   def fcall(function, keys \\ [], args \\ []) do
     ["FCALL", function, to_string(length(keys))] ++ keys ++ args

--- a/lib/redis/commands/search.ex
+++ b/lib/redis/commands/search.ex
@@ -1,28 +1,40 @@
 defmodule Redis.Commands.Search do
   @moduledoc """
-  Command builders for Redis Search (FT.*) operations (Redis 8+ / RediSearch).
+  Command builders for RediSearch (FT.*) full-text search and indexing.
 
-  Includes a schema builder DSL for `FT.CREATE`.
+  Provides pure functions for creating and managing search indexes, running
+  full-text and numeric queries, performing aggregations, and managing
+  auto-complete suggestion dictionaries. Includes a schema builder DSL that
+  translates Elixir tuples into the FT.CREATE SCHEMA syntax.
 
-  ## Usage
+  All functions return command lists for use with `Redis.command/2` or
+  `Redis.pipeline/2`.
 
-      # Create an index on JSON documents
+  ## Examples
+
+      # Create a JSON index with text, numeric, and tag fields
       Redis.command(conn, Search.create("idx:users", :json,
         prefix: "user:",
         schema: [
           {"$.name", :text, as: "name"},
-          {"$.age", :numeric, as: "age"},
+          {"$.age", :numeric, as: "age", sortable: true},
           {"$.email", :tag, as: "email"}
         ]
       ))
 
-      # Search
-      Redis.command(conn, Search.search("idx:users", "@name:Alice"))
+      # Full-text search with sorting and pagination
+      Redis.command(conn, Search.search("idx:users", "@name:Alice",
+        sortby: {"age", :asc},
+        limit: {0, 20},
+        return: ["name", "age"]
+      ))
 
-      # Aggregate
+      # Aggregation with grouping and reduction
       Redis.command(conn, Search.aggregate("idx:users", "*",
         groupby: ["@age"],
-        reduce: [{"COUNT", 0, as: "count"}]
+        reduce: [{"COUNT", 0, as: "count"}],
+        sortby: [{"@count", :desc}],
+        limit: {0, 10}
       ))
   """
 

--- a/lib/redis/commands/server.ex
+++ b/lib/redis/commands/server.ex
@@ -1,19 +1,72 @@
 defmodule Redis.Commands.Server do
   @moduledoc """
-  Command builders for Redis server operations.
+  Command builders for Redis server administration and introspection.
 
-  ## TODO (Phase 2)
+  Provides pure functions that build command lists for server-level operations
+  including connectivity checks (PING), server information (INFO, DBSIZE, TIME),
+  configuration management (CONFIG GET/SET), client management (CLIENT LIST/KILL),
+  persistence controls (SAVE, BGSAVE), and ACL management. Each function returns
+  a plain list of strings suitable for passing to `Redis.command/2` or
+  `Redis.pipeline/2`.
 
-  CLIENT, CONFIG, DBSIZE, DEBUG, FLUSHALL, FLUSHDB, INFO,
-  LASTSAVE, MONITOR, PSYNC, REPLICAOF, SAVE, SHUTDOWN, SLOWLOG,
-  TIME, WAIT
+  These functions contain no connection or networking logic -- they only construct
+  the Redis protocol command as a list.
+
+  ## Examples
+
+  Ping the server:
+
+      iex> Redis.Commands.Server.ping()
+      ["PING"]
+      iex> Redis.Commands.Server.ping("hello")
+      ["PING", "hello"]
+
+  Retrieve a specific INFO section:
+
+      iex> Redis.Commands.Server.info("memory")
+      ["INFO", "memory"]
+
+  Read and update a configuration parameter:
+
+      iex> Redis.Commands.Server.config_get("maxmemory")
+      ["CONFIG", "GET", "maxmemory"]
+      iex> Redis.Commands.Server.config_set("maxmemory", "256mb")
+      ["CONFIG", "SET", "maxmemory", "256mb"]
   """
 
+  @doc """
+  Builds a PING command, optionally with a custom message.
+
+  When called without arguments, the server responds with "PONG". When called
+  with a message, the server echoes that message back.
+
+  ## Examples
+
+      iex> Redis.Commands.Server.ping()
+      ["PING"]
+
+      iex> Redis.Commands.Server.ping("hello")
+      ["PING", "hello"]
+  """
   @spec ping(String.t() | nil) :: [String.t()]
   def ping(message \\ nil) do
     if message, do: ["PING", message], else: ["PING"]
   end
 
+  @doc """
+  Builds an INFO command to retrieve server information.
+
+  When called without arguments, returns all sections. Pass a section name
+  (e.g., "memory", "replication", "stats") to limit the response.
+
+  ## Examples
+
+      iex> Redis.Commands.Server.info()
+      ["INFO"]
+
+      iex> Redis.Commands.Server.info("replication")
+      ["INFO", "replication"]
+  """
   @spec info(String.t() | nil) :: [String.t()]
   def info(section \\ nil) do
     if section, do: ["INFO", section], else: ["INFO"]
@@ -39,6 +92,19 @@ defmodule Redis.Commands.Server do
   @spec client_info() :: [String.t()]
   def client_info, do: ["CLIENT", "INFO"]
 
+  @doc """
+  Builds a CLIENT LIST command to retrieve information about connected clients.
+
+  Supports filtering by client type (`:type`) or specific client IDs (`:id`).
+
+  ## Examples
+
+      iex> Redis.Commands.Server.client_list()
+      ["CLIENT", "LIST"]
+
+      iex> Redis.Commands.Server.client_list(type: "normal")
+      ["CLIENT", "LIST", "TYPE", "normal"]
+  """
   @spec client_list(keyword()) :: [String.t()]
   def client_list(opts \\ []) do
     cmd = ["CLIENT", "LIST"]
@@ -76,6 +142,17 @@ defmodule Redis.Commands.Server do
     cmd
   end
 
+  @doc """
+  Builds a CONFIG GET command to read a server configuration parameter.
+
+  Supports glob-style patterns (e.g., "max*") to retrieve multiple parameters
+  at once.
+
+  ## Example
+
+      iex> Redis.Commands.Server.config_get("maxmemory")
+      ["CONFIG", "GET", "maxmemory"]
+  """
   @spec config_get(String.t()) :: [String.t()]
   def config_get(parameter), do: ["CONFIG", "GET", parameter]
 

--- a/lib/redis/commands/set.ex
+++ b/lib/redis/commands/set.ex
@@ -2,34 +2,91 @@ defmodule Redis.Commands.Set do
   @moduledoc """
   Command builders for Redis set operations.
 
-  ## TODO (Phase 2)
+  This module provides pure functions that build Redis SET command lists.
+  Sets are unordered collections of unique strings, useful for membership
+  tracking, tagging, and computing intersections, unions, and differences
+  across collections.
 
-  SADD, SCARD, SDIFF, SDIFFSTORE, SINTER, SINTERCARD, SINTERSTORE,
-  SISMEMBER, SMEMBERS, SMISMEMBER, SMOVE, SPOP, SRANDMEMBER, SREM,
-  SSCAN, SUNION, SUNIONSTORE
+  Every function returns a plain list of strings (a command). To execute
+  a command, pass the result to `Redis.command/2`; to batch several
+  commands in a single round trip, use `Redis.pipeline/2`.
+
+  ## Examples
+
+  Adding members and retrieving a set:
+
+      iex> Redis.command(conn, Redis.Commands.Set.sadd("tags", ["elixir", "redis", "otp"]))
+      {:ok, 3}
+
+      iex> Redis.command(conn, Redis.Commands.Set.smembers("tags"))
+      {:ok, ["elixir", "redis", "otp"]}
+
+  Set operations -- intersection and union:
+
+      iex> Redis.pipeline(conn, [
+      ...>   Redis.Commands.Set.sadd("set:a", ["1", "2", "3"]),
+      ...>   Redis.Commands.Set.sadd("set:b", ["2", "3", "4"]),
+      ...>   Redis.Commands.Set.sinter(["set:a", "set:b"]),
+      ...>   Redis.Commands.Set.sunion(["set:a", "set:b"])
+      ...> ])
+      {:ok, [3, 3, ["2", "3"], ["1", "2", "3", "4"]]}
+
+  Removing members:
+
+      iex> Redis.command(conn, Redis.Commands.Set.srem("tags", ["otp"]))
+      {:ok, 1}
   """
 
+  @doc """
+  Builds a SADD command to add one or more `members` to the set at `key`.
+
+  Returns the number of members that were added (excluding duplicates).
+  """
   @spec sadd(String.t(), [String.t()]) :: [String.t()]
   def sadd(key, members) when is_list(members), do: ["SADD", key | members]
 
+  @doc """
+  Builds a SREM command to remove one or more `members` from the set at `key`.
+
+  Returns the number of members that were actually removed.
+  """
   @spec srem(String.t(), [String.t()]) :: [String.t()]
   def srem(key, members) when is_list(members), do: ["SREM", key | members]
 
+  @doc """
+  Builds a SMEMBERS command to return all members of the set at `key`.
+
+  For large sets, consider `sscan/3` instead to iterate incrementally.
+  """
   @spec smembers(String.t()) :: [String.t()]
   def smembers(key), do: ["SMEMBERS", key]
 
+  @doc """
+  Builds a SISMEMBER command to test whether `member` belongs to the set at `key`.
+
+  Returns 1 if the member exists, 0 otherwise.
+  """
   @spec sismember(String.t(), String.t()) :: [String.t()]
   def sismember(key, member), do: ["SISMEMBER", key, member]
 
   @spec scard(String.t()) :: [String.t()]
   def scard(key), do: ["SCARD", key]
 
+  @doc """
+  Builds a SDIFF command to return members in the first set that are not in any
+  of the subsequent sets listed in `keys`.
+  """
   @spec sdiff([String.t()]) :: [String.t()]
   def sdiff(keys) when is_list(keys), do: ["SDIFF" | keys]
 
   @spec sdiffstore(String.t(), [String.t()]) :: [String.t()]
   def sdiffstore(destination, keys) when is_list(keys), do: ["SDIFFSTORE", destination | keys]
 
+  @doc """
+  Builds a SINTER command to return the intersection of all sets in `keys`.
+
+  Only members present in every listed set are returned.
+  """
   @spec sinter([String.t()]) :: [String.t()]
   def sinter(keys) when is_list(keys), do: ["SINTER" | keys]
 
@@ -66,6 +123,9 @@ defmodule Redis.Commands.Set do
     cmd
   end
 
+  @doc """
+  Builds a SUNION command to return the union of all sets in `keys`.
+  """
   @spec sunion([String.t()]) :: [String.t()]
   def sunion(keys) when is_list(keys), do: ["SUNION" | keys]
 

--- a/lib/redis/commands/sorted_set.ex
+++ b/lib/redis/commands/sorted_set.ex
@@ -2,16 +2,48 @@ defmodule Redis.Commands.SortedSet do
   @moduledoc """
   Command builders for Redis sorted set operations.
 
-  ## TODO (Phase 2)
+  This module provides pure functions that build Redis ZSET (sorted set)
+  command lists. Sorted sets associate a floating-point score with each
+  unique member, keeping the collection ordered by score. They are the
+  backbone of leaderboards, priority queues, rate limiters, and
+  time-series indexes in Redis.
 
-  ZADD, ZCARD, ZCOUNT, ZDIFF, ZDIFFSTORE, ZINCRBY, ZINTER,
-  ZINTERCARD, ZINTERSTORE, ZLEXCOUNT, ZMPOP, ZMSCORE, ZPOPMAX,
-  ZPOPMIN, ZRANDMEMBER, ZRANGE, ZRANGEBYLEX, ZRANGEBYSCORE,
-  ZRANGESTORE, ZRANK, ZREM, ZREMRANGEBYLEX, ZREMRANGEBYRANK,
-  ZREMRANGEBYSCORE, ZREVRANGE, ZREVRANGEBYSCORE, ZREVRANK,
-  ZSCAN, ZSCORE, ZUNION, ZUNIONSTORE
+  Every function returns a plain list of strings (a command). To execute
+  a command, pass the result to `Redis.command/2`; to batch several
+  commands in a single round trip, use `Redis.pipeline/2`.
+
+  ## Examples
+
+  Adding scored members and querying by rank:
+
+      iex> Redis.command(conn, Redis.Commands.SortedSet.zadd("leaderboard", [{100, "alice"}, {200, "bob"}]))
+      {:ok, 2}
+
+      iex> Redis.command(conn, Redis.Commands.SortedSet.zrange("leaderboard", "0", "-1", withscores: true))
+      {:ok, ["alice", "100", "bob", "200"]}
+
+  Range queries by score:
+
+      iex> Redis.command(conn, Redis.Commands.SortedSet.zrangebyscore("leaderboard", "150", "+inf", withscores: true))
+      {:ok, ["bob", "200"]}
+
+  Incrementing scores for a leaderboard:
+
+      iex> Redis.command(conn, Redis.Commands.SortedSet.zincrby("leaderboard", 50, "alice"))
+      {:ok, "150"}
   """
 
+  @doc """
+  Builds a ZADD command to add members with scores to the sorted set at `key`.
+
+  `score_members` is a list of `{score, member}` tuples. Supports the
+  following options:
+
+    * `:nx` - only add new members, never update existing ones
+    * `:xx` - only update existing members, never add new ones
+    * `:gt` - only update when the new score is greater than the current score
+    * `:lt` - only update when the new score is less than the current score
+  """
   @spec zadd(String.t(), [{float() | integer(), String.t()}], keyword()) :: [String.t()]
   def zadd(key, score_members, opts \\ []) do
     cmd = ["ZADD", key]
@@ -22,9 +54,24 @@ defmodule Redis.Commands.SortedSet do
     cmd ++ Enum.flat_map(score_members, fn {score, member} -> [to_string(score), member] end)
   end
 
+  @doc """
+  Builds a ZSCORE command to return the score of `member` in the sorted set
+  at `key`.
+
+  Returns `nil` if the member or key does not exist.
+  """
   @spec zscore(String.t(), String.t()) :: [String.t()]
   def zscore(key, member), do: ["ZSCORE", key, member]
 
+  @doc """
+  Builds a ZRANGE command to return members between `min` and `max` positions.
+
+  By default the range is by rank (0-based index). Options:
+
+    * `:rev` - return elements in reverse order (highest to lowest)
+    * `:withscores` - include scores alongside members in the reply
+    * `:limit` - a `{offset, count}` tuple to paginate results
+  """
   @spec zrange(String.t(), String.t(), String.t(), keyword()) :: [String.t()]
   def zrange(key, min, max, opts \\ []) do
     cmd = ["ZRANGE", key, to_string(min), to_string(max)]
@@ -39,6 +86,13 @@ defmodule Redis.Commands.SortedSet do
     cmd
   end
 
+  @doc """
+  Builds a ZRANK command to return the 0-based rank of `member` in the sorted
+  set at `key`, ordered from lowest to highest score.
+
+  Returns `nil` if the member does not exist. See `zrevrank/2` for the
+  reverse ordering.
+  """
   @spec zrank(String.t(), String.t()) :: [String.t()]
   def zrank(key, member), do: ["ZRANK", key, member]
 
@@ -62,6 +116,13 @@ defmodule Redis.Commands.SortedSet do
     ["ZDIFFSTORE", destination, to_string(numkeys)] ++ keys
   end
 
+  @doc """
+  Builds a ZINCRBY command to increment the score of `member` in the sorted
+  set at `key` by `increment`.
+
+  If the member does not exist it is added with `increment` as its score.
+  Returns the new score as a string.
+  """
   @spec zincrby(String.t(), float() | integer(), String.t()) :: [String.t()]
   def zincrby(key, increment, member), do: ["ZINCRBY", key, to_string(increment), member]
 
@@ -137,6 +198,16 @@ defmodule Redis.Commands.SortedSet do
       else: cmd
   end
 
+  @doc """
+  Builds a ZRANGEBYSCORE command to return members with scores between `min`
+  and `max` (inclusive by default).
+
+  Use `"-inf"` and `"+inf"` for open-ended ranges, or prefix a bound with
+  `"("` for an exclusive boundary (e.g. `"(100"`). Options:
+
+    * `:withscores` - include scores in the reply
+    * `:limit` - a `{offset, count}` tuple to paginate results
+  """
   @spec zrangebyscore(String.t(), String.t(), String.t(), keyword()) :: [String.t()]
   def zrangebyscore(key, min, max, opts \\ []) do
     cmd = ["ZRANGEBYSCORE", key, min, max]

--- a/lib/redis/commands/stream.ex
+++ b/lib/redis/commands/stream.ex
@@ -2,13 +2,47 @@ defmodule Redis.Commands.Stream do
   @moduledoc """
   Command builders for Redis stream operations.
 
-  ## TODO (Phase 2/4)
+  This module provides pure functions that build Redis Stream command
+  lists. Streams are append-only log structures that support fan-out
+  reads, consumer groups with at-least-once delivery, and automatic
+  ID generation. They are well-suited for event sourcing, task queues,
+  and activity feeds.
 
-  XADD, XLEN, XRANGE, XREVRANGE, XREAD, XTRIM,
-  XGROUP CREATE, XGROUP DESTROY, XGROUP SETID,
-  XREADGROUP, XACK, XCLAIM, XAUTOCLAIM, XPENDING, XINFO
+  Every function returns a plain list of strings (a command). To execute
+  a command, pass the result to `Redis.command/2`; to batch several
+  commands in a single round trip, use `Redis.pipeline/2`.
+
+  ## Examples
+
+  Appending entries and reading them back:
+
+      iex> Redis.command(conn, Redis.Commands.Stream.xadd("events", "*", [{"type", "click"}, {"url", "/home"}]))
+      {:ok, "1234567890123-0"}
+
+      iex> Redis.command(conn, Redis.Commands.Stream.xread(streams: [{"events", "0"}], count: 10))
+      {:ok, [["events", [["1234567890123-0", ["type", "click", "url", "/home"]]]]]}
+
+  Consumer group pattern -- read, process, acknowledge:
+
+      iex> Redis.command(conn, Redis.Commands.Stream.xgroup_create("events", "workers", "0", mkstream: true))
+      {:ok, "OK"}
+
+      iex> Redis.command(conn, Redis.Commands.Stream.xreadgroup("workers", "worker-1", streams: [{"events", ">"}], count: 5))
+      {:ok, [["events", [["1234567890123-0", ["type", "click", "url", "/home"]]]]]}
+
+      iex> Redis.command(conn, Redis.Commands.Stream.xack("events", "workers", ["1234567890123-0"]))
+      {:ok, 1}
   """
 
+  @doc """
+  Builds an XADD command to append an entry to the stream at `key`.
+
+  `id` defaults to `"*"` which lets Redis auto-generate a monotonic ID.
+  `fields` is a list of `{field, value}` tuples representing the entry
+  payload. Options:
+
+    * `:maxlen` - cap the stream length with approximate trimming (`~`)
+  """
   @spec xadd(String.t(), String.t(), [{String.t(), String.t()}], keyword()) :: [String.t()]
   def xadd(key, id \\ "*", fields, opts \\ []) do
     cmd = ["XADD", key]
@@ -17,6 +51,9 @@ defmodule Redis.Commands.Stream do
     cmd ++ Enum.flat_map(fields, fn {f, v} -> [f, to_string(v)] end)
   end
 
+  @doc """
+  Builds an XLEN command to return the number of entries in the stream at `key`.
+  """
   @spec xlen(String.t()) :: [String.t()]
   def xlen(key), do: ["XLEN", key]
 
@@ -26,6 +63,16 @@ defmodule Redis.Commands.Stream do
     if opts[:count], do: cmd ++ ["COUNT", to_string(opts[:count])], else: cmd
   end
 
+  @doc """
+  Builds an XREAD command to read entries from one or more streams.
+
+  Options:
+
+    * `:streams` (required) - a list of `{stream_key, last_id}` tuples.
+      Use `"0"` to read from the beginning or `"$"` to read only new entries.
+    * `:count` - maximum number of entries to return per stream
+    * `:block` - block for up to this many milliseconds waiting for new data
+  """
   @spec xread(keyword()) :: [String.t()]
   def xread(opts) do
     cmd = ["XREAD"]
@@ -34,6 +81,13 @@ defmodule Redis.Commands.Stream do
     cmd ++ ["STREAMS" | flatten_streams(opts[:streams])]
   end
 
+  @doc """
+  Builds an XACK command to acknowledge one or more stream entries.
+
+  Acknowledging an entry removes it from the consumer group's pending
+  entries list (PEL). Returns the number of entries successfully
+  acknowledged.
+  """
   @spec xack(String.t(), String.t(), [String.t()]) :: [String.t()]
   def xack(key, group, ids) when is_list(ids), do: ["XACK", key, group | ids]
 
@@ -86,6 +140,18 @@ defmodule Redis.Commands.Stream do
     cmd
   end
 
+  @doc """
+  Builds an XREADGROUP command to read entries via a consumer group.
+
+  Each entry delivered to `consumer` within `group` must later be
+  acknowledged with `xack/3`. Options:
+
+    * `:streams` (required) - a list of `{stream_key, id}` tuples.
+      Use `">"` as the id to receive only new, undelivered messages.
+    * `:count` - maximum number of entries to return per stream
+    * `:block` - block for up to this many milliseconds waiting for new data
+    * `:noack` - do not require acknowledgement for delivered entries
+  """
   @spec xreadgroup(String.t(), String.t(), keyword()) :: [String.t()]
   def xreadgroup(group, consumer, opts) do
     cmd = ["XREADGROUP", "GROUP", group, consumer]
@@ -123,6 +189,12 @@ defmodule Redis.Commands.Stream do
   @spec xinfo_groups(String.t()) :: [String.t()]
   def xinfo_groups(key), do: ["XINFO", "GROUPS", key]
 
+  @doc """
+  Builds an XINFO STREAM command to return metadata about the stream at `key`.
+
+  Pass `full: true` to include detailed information about every consumer
+  group, consumer, and pending entry.
+  """
   @spec xinfo_stream(String.t(), keyword()) :: [String.t()]
   def xinfo_stream(key, opts \\ []) do
     cmd = ["XINFO", "STREAM", key]

--- a/lib/redis/commands/string.ex
+++ b/lib/redis/commands/string.ex
@@ -2,16 +2,49 @@ defmodule Redis.Commands.String do
   @moduledoc """
   Command builders for Redis string operations.
 
-  ## TODO (Phase 2)
+  This module provides pure functions that return Redis command lists for
+  string data type operations, including getting/setting values, atomic
+  counters, and bulk operations. All functions return a list of strings
+  suitable for use with `Redis.command/2` or `Redis.pipeline/2`.
 
-  APPEND, DECR, DECRBY, GET, GETDEL, GETEX, GETRANGE, GETSET,
-  INCR, INCRBY, INCRBYFLOAT, MGET, MSET, MSETNX, SET, SETEX,
-  SETNX, SETRANGE, STRLEN
+  ## Examples
+
+      # SET with expiry and NX (only if key does not exist)
+      iex> Redis.Commands.String.set("session:abc", "user_1", ex: 3600, nx: true)
+      ["SET", "session:abc", "user_1", "EX", "3600", "NX"]
+
+      # GET a value
+      iex> Redis.Commands.String.get("session:abc")
+      ["GET", "session:abc"]
+
+      # Atomic counter increment
+      iex> Redis.Commands.String.incr("page:views")
+      ["INCR", "page:views"]
+
+      # Fetch multiple keys at once
+      iex> Redis.Commands.String.mget(["key1", "key2", "key3"])
+      ["MGET", "key1", "key2", "key3"]
   """
 
+  @doc """
+  Builds a GET command to retrieve the value stored at `key`.
+
+  Returns `nil` from Redis when the key does not exist.
+  """
   @spec get(String.t()) :: [String.t()]
   def get(key), do: ["GET", key]
 
+  @doc """
+  Builds a SET command to store `value` at `key`.
+
+  ## Options
+
+    * `:ex` - set expiry in seconds
+    * `:px` - set expiry in milliseconds
+    * `:nx` - only set if the key does not already exist
+    * `:xx` - only set if the key already exists
+    * `:get` - return the old value stored at the key
+  """
   @spec set(String.t(), String.t(), keyword()) :: [String.t()]
   def set(key, value, opts \\ []) do
     cmd = ["SET", key, to_string(value)]
@@ -23,6 +56,12 @@ defmodule Redis.Commands.String do
     cmd
   end
 
+  @doc """
+  Builds an MGET command to retrieve the values of multiple `keys` in one call.
+
+  Returns a list of values in the same order as the requested keys.
+  Keys that do not exist produce `nil` in the corresponding position.
+  """
   @spec mget([String.t()]) :: [String.t()]
   def mget(keys) when is_list(keys), do: ["MGET" | keys]
 
@@ -31,9 +70,18 @@ defmodule Redis.Commands.String do
     ["MSET" | Enum.flat_map(pairs, fn {k, v} -> [k, to_string(v)] end)]
   end
 
+  @doc """
+  Builds an INCR command to atomically increment the integer value at `key` by 1.
+
+  If the key does not exist, it is initialized to 0 before incrementing.
+  """
   @spec incr(String.t()) :: [String.t()]
   def incr(key), do: ["INCR", key]
 
+  @doc """
+  Builds an INCRBY command to atomically increment the integer value at `key`
+  by `amount`. The amount may be negative to decrement.
+  """
   @spec incrby(String.t(), integer()) :: [String.t()]
   def incrby(key, amount), do: ["INCRBY", key, to_string(amount)]
 
@@ -43,12 +91,29 @@ defmodule Redis.Commands.String do
   @spec decrby(String.t(), integer()) :: [String.t()]
   def decrby(key, amount), do: ["DECRBY", key, to_string(amount)]
 
+  @doc """
+  Builds an APPEND command to append `value` to the string already stored at
+  `key`. If the key does not exist, it is created with `value` as its content.
+  Returns the length of the string after the append operation.
+  """
   @spec append(String.t(), String.t()) :: [String.t()]
   def append(key, value), do: ["APPEND", key, value]
 
   @spec getdel(String.t()) :: [String.t()]
   def getdel(key), do: ["GETDEL", key]
 
+  @doc """
+  Builds a GETEX command to retrieve the value at `key` and optionally
+  set or clear its expiration.
+
+  ## Options
+
+    * `:ex` - set expiry in seconds
+    * `:px` - set expiry in milliseconds
+    * `:exat` - set expiry as a Unix timestamp in seconds
+    * `:pxat` - set expiry as a Unix timestamp in milliseconds
+    * `:persist` - remove the existing expiry
+  """
   @spec getex(String.t(), keyword()) :: [String.t()]
   def getex(key, opts \\ []) do
     cmd = ["GETEX", key]

--- a/lib/redis/commands/tdigest.ex
+++ b/lib/redis/commands/tdigest.ex
@@ -1,14 +1,43 @@
 defmodule Redis.Commands.TDigest do
   @moduledoc """
-  Command builders for Redis t-digest operations.
+  Command builders for Redis t-digest (`TDIGEST.*`) operations.
+
+  A t-digest is a compact data structure for estimating percentiles and
+  quantiles from streaming or distributed data. It works by maintaining a
+  sorted set of centroids that adaptively merge as data arrives, providing
+  high accuracy at the tails of the distribution (e.g. p99, p99.9) where it
+  matters most. Typical use cases include latency monitoring, SLA tracking,
+  and any scenario where you need to answer "what value is at the Nth
+  percentile?" without storing every observation.
+
+  All functions in this module are pure and return a command list (a list of
+  strings) suitable for passing to `Redis.command/2` or `Redis.pipeline/2`.
+
+  ## Examples
+
+      # Create a t-digest and add observations
+      Redis.pipeline(conn, [
+        TDigest.create("latency"),
+        TDigest.add("latency", [1.2, 3.4, 5.6, 7.8, 100.0])
+      ])
+
+      # Query the 50th and 99th percentiles
+      Redis.command(conn, TDigest.quantile("latency", [0.5, 0.99]))
   """
 
+  @doc """
+  Creates an empty t-digest sketch. Pass `compression: n` to control the
+  trade-off between accuracy and memory (higher = more accurate, default 100).
+  """
   @spec create(String.t(), keyword()) :: [String.t()]
   def create(key, opts \\ []) do
     cmd = ["TDIGEST.CREATE", key]
     if opts[:compression], do: cmd ++ ["COMPRESSION", to_string(opts[:compression])], else: cmd
   end
 
+  @doc """
+  Adds one or more numeric observations to the t-digest sketch.
+  """
   @spec add(String.t(), [float()]) :: [String.t()]
   def add(key, values) when is_list(values) do
     ["TDIGEST.ADD", key | Enum.map(values, &to_string/1)]
@@ -19,6 +48,10 @@ defmodule Redis.Commands.TDigest do
     ["TDIGEST.CDF", key | Enum.map(values, &to_string/1)]
   end
 
+  @doc """
+  Estimates the value at each given quantile (0.0 to 1.0). For example,
+  `quantile(key, [0.5, 0.99])` returns the estimated median and p99 values.
+  """
   @spec quantile(String.t(), [float()]) :: [String.t()]
   def quantile(key, quantiles) when is_list(quantiles) do
     ["TDIGEST.QUANTILE", key | Enum.map(quantiles, &to_string/1)]

--- a/lib/redis/commands/timeseries.ex
+++ b/lib/redis/commands/timeseries.ex
@@ -1,8 +1,36 @@
 defmodule Redis.Commands.TimeSeries do
   @moduledoc """
-  Command builders for Redis TimeSeries operations.
+  Command builders for Redis TimeSeries (`TS.*`) operations.
+
+  Redis TimeSeries is an append-only data structure optimized for storing
+  timestamped numeric samples. It supports automatic downsampling via
+  compaction rules, label-based indexing for multi-series queries, and
+  built-in aggregation functions (avg, sum, min, max, count, etc.) over
+  arbitrary time windows. Common use cases include metrics collection, IoT
+  sensor data, financial tick data, and application monitoring.
+
+  All functions in this module are pure and return a command list (a list of
+  strings) suitable for passing to `Redis.command/2` or `Redis.pipeline/2`.
+
+  ## Examples
+
+      # Create a time series and add a sample
+      Redis.pipeline(conn, [
+        TimeSeries.ts_create("temp:office", labels: %{"location" => "office"}),
+        TimeSeries.ts_add("temp:office", "*", 22.5)
+      ])
+
+      # Query a time range with 1-hour average aggregation
+      Redis.command(conn, TimeSeries.ts_range("temp:office", "-", "+",
+        aggregation: {:avg, 3_600_000}
+      ))
   """
 
+  @doc """
+  Creates a new time series key. Accepts options including `:retention`
+  (max age in milliseconds), `:labels` (a map or keyword list of label
+  key-value pairs), `:encoding`, `:chunk_size`, and `:duplicate_policy`.
+  """
   @spec ts_create(String.t(), keyword()) :: [String.t()]
   def ts_create(key, opts \\ []) do
     cmd = ["TS.CREATE", key]
@@ -34,6 +62,11 @@ defmodule Redis.Commands.TimeSeries do
     cmd
   end
 
+  @doc """
+  Appends a sample to a time series. Use `"*"` as the timestamp to let Redis
+  assign the current server time. Accepts the same label and retention options
+  as `ts_create/2`, plus `:on_duplicate` for handling duplicate timestamps.
+  """
   @spec ts_add(String.t(), String.t() | integer(), String.t() | number(), keyword()) :: [
           String.t()
         ]
@@ -99,6 +132,11 @@ defmodule Redis.Commands.TimeSeries do
     cmd ++ ["FILTER" | filters]
   end
 
+  @doc """
+  Queries samples in the time range `from..to` (inclusive). Use `"-"` and `"+"`
+  for the minimum and maximum timestamps. Supports `:count`, `:aggregation`
+  (e.g. `{:avg, 60_000}`), `:filter_by_ts`, and `:filter_by_value` options.
+  """
   @spec ts_range(String.t(), String.t() | integer(), String.t() | integer(), keyword()) :: [
           String.t()
         ]

--- a/lib/redis/commands/topk.ex
+++ b/lib/redis/commands/topk.ex
@@ -1,17 +1,49 @@
 defmodule Redis.Commands.TopK do
   @moduledoc """
-  Command builders for Redis Top-K operations.
+  Command builders for Redis Top-K (`TOPK.*`) operations.
+
+  Top-K is a probabilistic data structure that tracks the **K most frequent
+  items** (heavy hitters) in a stream of data. It uses a Count-Min Sketch
+  internally to approximate item frequencies, making it very memory-efficient
+  for finding popular items in high-volume streams without storing every
+  element.
+
+  All functions in this module are pure and return a command list (a list of
+  strings) suitable for passing to `Redis.command/2` or `Redis.pipeline/2`.
+
+  ## Examples
+
+      # Track the top 3 most popular pages
+      Redis.command(conn, TopK.reserve("popular_pages", 3))
+
+      # Record page views and retrieve the current top-K list
+      Redis.pipeline(conn, [
+        TopK.add("popular_pages", ["/home", "/about", "/home", "/pricing"]),
+        TopK.list("popular_pages", withcount: true)
+      ])
   """
 
+  @doc """
+  Adds one or more items to the Top-K structure.
+
+  Returns a list where each element is either `nil` (if no item was evicted)
+  or the name of the item that was evicted to make room.
+  """
   @spec add(String.t(), [String.t()]) :: [String.t()]
   def add(key, items) when is_list(items), do: ["TOPK.ADD", key | items]
 
+  @doc """
+  Checks whether one or more items are currently in the Top-K list.
+  """
   @spec query(String.t(), [String.t()]) :: [String.t()]
   def query(key, items) when is_list(items), do: ["TOPK.QUERY", key | items]
 
   @spec count(String.t(), [String.t()]) :: [String.t()]
   def count(key, items) when is_list(items), do: ["TOPK.COUNT", key | items]
 
+  @doc """
+  Returns the current Top-K list. Pass `withcount: true` to include counts.
+  """
   @spec list(String.t(), keyword()) :: [String.t()]
   def list(key, opts \\ []) do
     cmd = ["TOPK.LIST", key]


### PR DESCRIPTION
Closes #47

## Summary

- All 21 command builder modules now have substantive `@moduledoc` with usage examples
- Key public functions have `@doc` strings (top 3-7 per module, not every function)
- Every moduledoc explains the pure-function / command-list pattern

## Modules updated

**Core data types:** String, Hash, List, Set, SortedSet, Stream
**Key management:** Key, Server
**Specialized:** Geo, Bitmap, HyperLogLog
**Pub/Sub + scripting:** PubSub, Script
**Redis Stack:** JSON, Search, Bloom, Cuckoo, TopK, CMS, TDigest, TimeSeries

## Test plan

- [ ] `mix compile --warnings-as-errors` passes
- [ ] `mix credo --strict` clean
- [ ] `mix docs` builds successfully
- [ ] Spot-check HexDocs rendering