### PR TITLE
test: property-based tests for RESP3 encode/decode

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -34,6 +34,7 @@ defmodule Redis.MixProject do
       {:ex_doc, "~> 0.34", only: :dev, runtime: false},
       {:dialyxir, "~> 1.4", only: [:dev, :test], runtime: false},
       {:credo, "~> 1.7", only: [:dev, :test], runtime: false},
+      {:stream_data, "~> 1.0", only: [:test]},
       {:redis_server_wrapper, "~> 0.2", only: [:test, :bench]},
       {:redix, "~> 1.5", only: :bench},
       {:benchee, "~> 1.0", only: :bench}

--- a/mix.lock
+++ b/mix.lock
@@ -17,5 +17,6 @@
   "redis_server_wrapper": {:hex, :redis_server_wrapper, "0.2.0", "bfe2eeac05f0f8976b110ee8e3c5a9d0371a16d2a9bc1055e010a18124c4578f", [:mix], [], "hexpm", "a93f6aaf8c2bbae193f833f63096d76920f9f8cc132e76ebee927c9e47a5c7e0"},
   "redix": {:hex, :redix, "1.5.3", "4eaae29c75e3285c0ff9957046b7c209aa7f72a023a17f0a9ea51c2a50ab5b0f", [:mix], [{:castore, "~> 0.1.0 or ~> 1.0", [hex: :castore, repo: "hexpm", optional: true]}, {:nimble_options, "~> 0.5.0 or ~> 1.0", [hex: :nimble_options, repo: "hexpm", optional: false]}, {:telemetry, "~> 0.4.0 or ~> 1.0", [hex: :telemetry, repo: "hexpm", optional: false]}], "hexpm", "7b06fb5246373af41f5826b03334dfa3f636347d4d5d98b4d455b699d425ae7e"},
   "statistex": {:hex, :statistex, "1.1.0", "7fec1eb2f580a0d2c1a05ed27396a084ab064a40cfc84246dbfb0c72a5c761e5", [:mix], [], "hexpm", "f5950ea26ad43246ba2cce54324ac394a4e7408fdcf98b8e230f503a0cba9cf5"},
+  "stream_data": {:hex, :stream_data, "1.3.0", "bde37905530aff386dea1ddd86ecbf00e6642dc074ceffc10b7d4e41dfd6aac9", [:mix], [], "hexpm", "3cc552e286e817dca43c98044c706eec9318083a1480c52ae2688b08e2936e3c"},
   "telemetry": {:hex, :telemetry, "1.4.1", "ab6de178e2b29b58e8256b92b382ea3f590a47152ca3651ea857a6cae05ac423", [:rebar3], [], "hexpm", "2172e05a27531d3d31dd9782841065c50dd5c3c7699d95266b2edd54c2dafa1c"},
 }

--- a/test/protocol/resp3_property_test.exs
+++ b/test/protocol/resp3_property_test.exs
@@ -1,0 +1,324 @@
+defmodule Redis.Protocol.RESP3PropertyTest do
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  alias Redis.Protocol.RESP3
+
+  # -------------------------------------------------------------------
+  # Generators
+  # -------------------------------------------------------------------
+
+  # Generate a RESP3-compatible Elixir value
+  defp resp3_value do
+    gen all(
+          value <-
+            one_of([
+              resp3_simple_string(),
+              resp3_integer(),
+              resp3_double(),
+              resp3_boolean(),
+              resp3_null(),
+              resp3_blob_string(),
+              resp3_array(),
+              resp3_map()
+            ])
+        ) do
+      value
+    end
+  end
+
+  # Simple string: any string without \r or \n
+  defp resp3_simple_string do
+    gen all(str <- string(:printable, min_length: 0, max_length: 100)) do
+      String.replace(str, ~r/[\r\n]/, "")
+    end
+  end
+
+  defp resp3_integer, do: integer(-1_000_000..1_000_000)
+
+  defp resp3_double do
+    gen all(f <- float(min: -1.0e10, max: 1.0e10)) do
+      # Avoid NaN/Inf since those have special atom representation
+      f
+    end
+  end
+
+  defp resp3_boolean, do: boolean()
+  defp resp3_null, do: constant(nil)
+
+  # Blob string: any binary (including embedded \r\n)
+  defp resp3_blob_string do
+    binary(min_length: 0, max_length: 200)
+  end
+
+  # Shallow array of scalar values (avoid deep nesting for performance)
+  defp resp3_array do
+    gen all(
+          elements <-
+            list_of(
+              one_of([
+                resp3_simple_string(),
+                resp3_integer(),
+                resp3_blob_string(),
+                resp3_boolean(),
+                resp3_null()
+              ]),
+              min_length: 0,
+              max_length: 10
+            )
+        ) do
+      elements
+    end
+  end
+
+  # Map with string keys and scalar values
+  defp resp3_map do
+    gen all(
+          pairs <-
+            list_of(
+              tuple({
+                resp3_simple_string(),
+                one_of([
+                  resp3_simple_string(),
+                  resp3_integer(),
+                  resp3_blob_string(),
+                  resp3_boolean(),
+                  resp3_null()
+                ])
+              }),
+              min_length: 0,
+              max_length: 5
+            )
+        ) do
+      Map.new(pairs)
+    end
+  end
+
+  # -------------------------------------------------------------------
+  # RESP3 wire format encoders (for building test data)
+  # -------------------------------------------------------------------
+
+  defp to_resp3_wire(value) when is_binary(value) do
+    # Encode as blob string to handle embedded \r\n safely
+    "$#{byte_size(value)}\r\n#{value}\r\n"
+  end
+
+  defp to_resp3_wire(value) when is_integer(value) do
+    ":#{value}\r\n"
+  end
+
+  defp to_resp3_wire(value) when is_float(value) do
+    ",#{value}\r\n"
+  end
+
+  defp to_resp3_wire(true), do: "#t\r\n"
+  defp to_resp3_wire(false), do: "#f\r\n"
+  defp to_resp3_wire(nil), do: "_\r\n"
+
+  defp to_resp3_wire(value) when is_list(value) do
+    elements = Enum.map_join(value, &to_resp3_wire/1)
+    "*#{length(value)}\r\n#{elements}"
+  end
+
+  defp to_resp3_wire(value) when is_map(value) and not is_struct(value) do
+    pairs =
+      Enum.map_join(value, fn {k, v} ->
+        to_resp3_wire(k) <> to_resp3_wire(v)
+      end)
+
+    "%#{map_size(value)}\r\n#{pairs}"
+  end
+
+  # -------------------------------------------------------------------
+  # Property tests
+  # -------------------------------------------------------------------
+
+  describe "encode/decode round-trip" do
+    property "encoding then decoding a command returns the original args as blob strings" do
+      check all(
+              args <-
+                list_of(binary(min_length: 1, max_length: 50), min_length: 1, max_length: 10)
+            ) do
+        encoded = RESP3.encode(args) |> IO.iodata_to_binary()
+
+        # Decoding an encoded command yields an array of the original binaries
+        assert {:ok, decoded, ""} = RESP3.decode(encoded)
+        assert decoded == args
+      end
+    end
+  end
+
+  describe "decode round-trip via wire format" do
+    property "simple strings decode correctly" do
+      check all(str <- resp3_simple_string(), str != "") do
+        wire = "+#{str}\r\n"
+        assert {:ok, ^str, ""} = RESP3.decode(wire)
+      end
+    end
+
+    property "integers decode correctly" do
+      check all(n <- integer(-1_000_000..1_000_000)) do
+        wire = ":#{n}\r\n"
+        assert {:ok, ^n, ""} = RESP3.decode(wire)
+      end
+    end
+
+    property "doubles decode correctly" do
+      check all(f <- float(min: -1.0e10, max: 1.0e10)) do
+        wire = ",#{f}\r\n"
+        assert {:ok, decoded, ""} = RESP3.decode(wire)
+        assert is_float(decoded)
+        assert_in_delta decoded, f, 1.0e-10
+      end
+    end
+
+    property "blob strings decode correctly (binary-safe)" do
+      check all(blob <- binary(min_length: 0, max_length: 500)) do
+        wire = "$#{byte_size(blob)}\r\n#{blob}\r\n"
+        assert {:ok, ^blob, ""} = RESP3.decode(wire)
+      end
+    end
+
+    property "booleans decode correctly" do
+      check all(b <- boolean()) do
+        wire = if b, do: "#t\r\n", else: "#f\r\n"
+        assert {:ok, ^b, ""} = RESP3.decode(wire)
+      end
+    end
+
+    property "arrays of integers decode correctly" do
+      check all(ints <- list_of(integer(), min_length: 0, max_length: 20)) do
+        elements = Enum.map_join(ints, fn n -> ":#{n}\r\n" end)
+        wire = "*#{length(ints)}\r\n#{elements}"
+        assert {:ok, ^ints, ""} = RESP3.decode(wire)
+      end
+    end
+
+    property "maps with string keys and integer values decode correctly" do
+      check all(
+              pairs <-
+                list_of(
+                  tuple({string(:ascii, min_length: 1, max_length: 20), integer()}),
+                  min_length: 0,
+                  max_length: 10
+                )
+            ) do
+        expected = Map.new(pairs)
+
+        wire_pairs =
+          Enum.map_join(pairs, fn {k, v} ->
+            "+#{k}\r\n:#{v}\r\n"
+          end)
+
+        wire = "%#{length(pairs)}\r\n#{wire_pairs}"
+        assert {:ok, decoded, ""} = RESP3.decode(wire)
+        assert decoded == expected
+      end
+    end
+  end
+
+  describe "decode/encode composite round-trip" do
+    property "encoding and decoding preserves arbitrary RESP3 values" do
+      check all(value <- resp3_value()) do
+        wire = to_resp3_wire(value)
+        assert {:ok, decoded, ""} = RESP3.decode(wire)
+        assert values_equal?(value, decoded)
+      end
+    end
+  end
+
+  describe "decoder robustness" do
+    property "decoder never crashes on arbitrary binary input" do
+      check all(data <- binary(min_length: 0, max_length: 500)) do
+        result = RESP3.decode(data)
+
+        assert match?({:ok, _, _}, result) or
+                 match?({:continuation, _}, result)
+      end
+    end
+
+    property "decoder never crashes on binary input with valid prefixes" do
+      check all(
+              prefix <-
+                member_of(["+", "-", ":", "$", "*", "_", "#", ",", "(", "!", "=", "%", "~", ">"]),
+              tail <- binary(min_length: 0, max_length: 200)
+            ) do
+        data = prefix <> tail
+        result = RESP3.decode(data)
+
+        assert match?({:ok, _, _}, result) or
+                 match?({:continuation, _}, result)
+      end
+    end
+
+    property "partial blob strings return continuation" do
+      check all(blob <- binary(min_length: 5, max_length: 100)) do
+        # Declare a length longer than the actual data
+        wire = "$#{byte_size(blob) + 10}\r\n#{blob}"
+        assert {:continuation, _} = RESP3.decode(wire)
+      end
+    end
+  end
+
+  describe "special doubles" do
+    test "nan decodes to :nan atom" do
+      assert {:ok, :nan, ""} = RESP3.decode(",nan\r\n")
+    end
+
+    test "nan.0 decodes to :nan atom" do
+      assert {:ok, :nan, ""} = RESP3.decode(",nan.0\r\n")
+    end
+
+    test "inf decodes to :infinity" do
+      assert {:ok, :infinity, ""} = RESP3.decode(",inf\r\n")
+    end
+
+    test "-inf decodes to :neg_infinity" do
+      assert {:ok, :neg_infinity, ""} = RESP3.decode(",-inf\r\n")
+    end
+  end
+
+  describe "concatenated responses" do
+    property "multiple concatenated responses all decode sequentially" do
+      check all(
+              values <-
+                list_of(one_of([resp3_integer(), resp3_boolean(), resp3_null()]),
+                  min_length: 1,
+                  max_length: 10
+                )
+            ) do
+        wire = Enum.map_join(values, &to_resp3_wire/1)
+
+        {decoded, rest} =
+          Enum.reduce(values, {[], wire}, fn _val, {acc, data} ->
+            assert {:ok, decoded, rest} = RESP3.decode(data)
+            {acc ++ [decoded], rest}
+          end)
+
+        assert decoded == values
+        assert rest == ""
+      end
+    end
+  end
+
+  # -------------------------------------------------------------------
+  # Helpers
+  # -------------------------------------------------------------------
+
+  # Compare values allowing float imprecision
+  defp values_equal?(a, b) when is_float(a) and is_float(b) do
+    abs(a - b) < 1.0e-10
+  end
+
+  defp values_equal?(a, b) when is_list(a) and is_list(b) do
+    length(a) == length(b) and
+      Enum.zip(a, b) |> Enum.all?(fn {x, y} -> values_equal?(x, y) end)
+  end
+
+  defp values_equal?(a, b) when is_map(a) and is_map(b) do
+    Map.keys(a) == Map.keys(b) and
+      Enum.all?(Map.keys(a), fn k -> values_equal?(Map.get(a, k), Map.get(b, k)) end)
+  end
+
+  defp values_equal?(a, b), do: a == b
+end


### PR DESCRIPTION
Closes #32

## Summary

- Add `stream_data` as test dependency
- 13 property tests + 4 unit tests for the RESP3 protocol layer

## Coverage

**Round-trip properties:**
- Encode then decode a command returns original args
- Every RESP3 scalar type survives wire format round-trip (strings, integers, doubles, booleans, blobs)
- Arrays of integers, maps with string keys
- Composite values with mixed types

**Robustness properties:**
- Decoder never crashes on arbitrary binary input (fuzz)
- Decoder never crashes on valid-prefix + random tail
- Partial blob strings always return continuations
- Concatenated responses decode sequentially without data loss

**Special values:**
- nan, nan.0, inf, -inf all decode correctly

## Test plan

- [ ] `mix test test/protocol/resp3_property_test.exs` passes (13 properties, 4 tests)
- [ ] `mix credo --strict` clean