### PR TITLE
feat: WATCH-based optimistic locking transactions

### DIFF
--- a/lib/redis.ex
+++ b/lib/redis.ex
@@ -67,6 +67,27 @@ defmodule Redis do
   @spec transaction(conn(), [[String.t()]], keyword()) :: {:ok, [term()]} | {:error, term()}
   def transaction(conn, commands, opts \\ []), do: Connection.transaction(conn, commands, opts)
 
+  @doc """
+  Executes a WATCH-based optimistic locking transaction.
+
+  Watches the given keys, calls `fun` to read values and build commands,
+  then executes in MULTI/EXEC. Retries automatically on conflict.
+
+      Redis.watch_transaction(conn, ["balance"], fn conn ->
+        {:ok, bal} = Redis.command(conn, ["GET", "balance"])
+        new_bal = String.to_integer(bal) + 100
+        [["SET", "balance", to_string(new_bal)]]
+      end)
+  """
+  @spec watch_transaction(
+          conn(),
+          [String.t()],
+          (conn() -> [[String.t()]] | {:abort, term()}),
+          keyword()
+        ) :: {:ok, [term()]} | {:error, term()}
+  def watch_transaction(conn, keys, fun, opts \\ []),
+    do: Connection.watch_transaction(conn, keys, fun, opts)
+
   @doc "Sends a command without waiting for a reply (CLIENT REPLY OFF/ON)."
   @spec noreply_command(conn(), [String.t()], keyword()) :: :ok | {:error, term()}
   def noreply_command(conn, args, opts \\ []), do: Connection.noreply_command(conn, args, opts)

--- a/lib/redis/connection/connection.ex
+++ b/lib/redis/connection/connection.ex
@@ -121,6 +121,95 @@ defmodule Redis.Connection do
   end
 
   @doc """
+  Executes a WATCH-based optimistic locking transaction.
+
+  Watches the given keys, calls `fun` with the connection to read current
+  values and compute commands, then executes those commands in a MULTI/EXEC
+  block. If any watched key was modified by another client, EXEC returns nil
+  and the function is retried (up to `:max_retries` times, default 3).
+
+  The function `fun` receives the connection and must return either:
+  - a list of commands to execute in the transaction
+  - `{:abort, reason}` to abort without executing
+
+  Returns `{:ok, results}` on success, `{:error, :watch_conflict}` if all
+  retries are exhausted, or `{:error, reason}` on other failures.
+
+  ## Example
+
+      Redis.Connection.watch_transaction(conn, ["account:1", "account:2"], fn conn ->
+        {:ok, bal1} = Redis.Connection.command(conn, ["GET", "account:1"])
+        {:ok, bal2} = Redis.Connection.command(conn, ["GET", "account:2"])
+
+        amount = 100
+        new1 = String.to_integer(bal1) - amount
+        new2 = String.to_integer(bal2) + amount
+
+        [
+          ["SET", "account:1", to_string(new1)],
+          ["SET", "account:2", to_string(new2)]
+        ]
+      end)
+  """
+  @spec watch_transaction(
+          GenServer.server(),
+          [String.t()],
+          (GenServer.server() -> [[String.t()]] | {:abort, term()}),
+          keyword()
+        ) :: {:ok, [term()]} | {:error, term()}
+  def watch_transaction(conn, keys, fun, opts \\ []) do
+    max_retries = Keyword.get(opts, :max_retries, 3)
+    do_watch_transaction(conn, keys, fun, opts, max_retries)
+  end
+
+  defp do_watch_transaction(_conn, _keys, _fun, _opts, 0) do
+    {:error, :watch_conflict}
+  end
+
+  defp do_watch_transaction(conn, keys, fun, opts, retries_left) do
+    timeout = Keyword.get(opts, :timeout, 5_000)
+
+    with {:ok, "OK"} <- GenServer.call(conn, {:command, ["WATCH" | keys]}, timeout),
+         {:ok, commands} <- safe_build_commands(conn, fun),
+         result <- GenServer.call(conn, {:transaction, commands}, timeout) do
+      case result do
+        {:error, :transaction_aborted} ->
+          # WATCH conflict — EXEC returned nil, retry
+          do_watch_transaction(conn, keys, fun, opts, retries_left - 1)
+
+        other ->
+          other
+      end
+    else
+      {:abort, reason} ->
+        # User aborted — unwatch and return error
+        GenServer.call(conn, {:command, ["UNWATCH"]}, timeout)
+        {:error, {:aborted, reason}}
+
+      {:error, _} = error ->
+        # Clean up WATCH state on error
+        catch_unwatch(conn, timeout)
+        error
+    end
+  end
+
+  defp safe_build_commands(conn, fun) do
+    case fun.(conn) do
+      {:abort, _} = abort -> abort
+      commands when is_list(commands) -> {:ok, commands}
+    end
+  rescue
+    e ->
+      {:error, {:user_function_error, e}}
+  end
+
+  defp catch_unwatch(conn, timeout) do
+    GenServer.call(conn, {:command, ["UNWATCH"]}, timeout)
+  catch
+    :exit, _ -> :ok
+  end
+
+  @doc """
   Sends a command without waiting for a reply.
   Uses CLIENT REPLY OFF/ON internally.
   """

--- a/test/watch_transaction_test.exs
+++ b/test/watch_transaction_test.exs
@@ -1,0 +1,146 @@
+defmodule Redis.WatchTransactionTest do
+  use ExUnit.Case, async: false
+
+  alias Redis.Connection
+
+  # Uses redis-server on port 6398 from test_helper.exs
+
+  setup do
+    {:ok, conn} = Connection.start_link(port: 6398)
+
+    on_exit(fn ->
+      case Connection.start_link(port: 6398) do
+        {:ok, cleanup} ->
+          Connection.command(cleanup, [
+            "DEL",
+            "watch:key",
+            "watch:a",
+            "watch:b",
+            "watch:counter"
+          ])
+
+          Connection.stop(cleanup)
+
+        _ ->
+          :ok
+      end
+    end)
+
+    {:ok, conn: conn}
+  end
+
+  describe "watch_transaction/4" do
+    test "basic optimistic locking transaction succeeds", %{conn: conn} do
+      Connection.command(conn, ["SET", "watch:key", "100"])
+
+      result =
+        Connection.watch_transaction(conn, ["watch:key"], fn c ->
+          {:ok, val} = Connection.command(c, ["GET", "watch:key"])
+          new_val = String.to_integer(val) + 50
+          [["SET", "watch:key", to_string(new_val)]]
+        end)
+
+      assert {:ok, ["OK"]} = result
+      assert {:ok, "150"} = Connection.command(conn, ["GET", "watch:key"])
+    end
+
+    test "multiple watched keys", %{conn: conn} do
+      Connection.command(conn, ["SET", "watch:a", "10"])
+      Connection.command(conn, ["SET", "watch:b", "20"])
+
+      result =
+        Connection.watch_transaction(conn, ["watch:a", "watch:b"], fn c ->
+          {:ok, a} = Connection.command(c, ["GET", "watch:a"])
+          {:ok, b} = Connection.command(c, ["GET", "watch:b"])
+          sum = String.to_integer(a) + String.to_integer(b)
+          [["SET", "watch:a", to_string(sum)]]
+        end)
+
+      assert {:ok, ["OK"]} = result
+      assert {:ok, "30"} = Connection.command(conn, ["GET", "watch:a"])
+    end
+
+    test "retries on conflict from concurrent modification", %{conn: conn} do
+      Connection.command(conn, ["SET", "watch:counter", "0"])
+
+      # Start a second connection to cause a conflict
+      {:ok, conn2} = Connection.start_link(port: 6398)
+
+      attempt = :counters.new(1, [:atomics])
+
+      result =
+        Connection.watch_transaction(conn, ["watch:counter"], fn c ->
+          :counters.add(attempt, 1, 1)
+          {:ok, val} = Connection.command(c, ["GET", "watch:counter"])
+          current = String.to_integer(val)
+
+          # On the first attempt, have conn2 modify the key to trigger conflict
+          if :counters.get(attempt, 1) == 1 do
+            Connection.command(conn2, ["SET", "watch:counter", "999"])
+          end
+
+          [["SET", "watch:counter", to_string(current + 1)]]
+        end)
+
+      assert {:ok, ["OK"]} = result
+      # After conflict, it retried and set to 999 + 1 = 1000
+      assert {:ok, "1000"} = Connection.command(conn, ["GET", "watch:counter"])
+      assert :counters.get(attempt, 1) == 2
+
+      Connection.stop(conn2)
+    end
+
+    test "returns :watch_conflict after max retries exhausted", %{conn: conn} do
+      Connection.command(conn, ["SET", "watch:key", "0"])
+      {:ok, conn2} = Connection.start_link(port: 6398)
+
+      result =
+        Connection.watch_transaction(
+          conn,
+          ["watch:key"],
+          fn c ->
+            {:ok, _} = Connection.command(c, ["GET", "watch:key"])
+            # Always cause a conflict
+            Connection.command(conn2, ["INCR", "watch:key"])
+            [["SET", "watch:key", "done"]]
+          end,
+          max_retries: 2
+        )
+
+      assert {:error, :watch_conflict} = result
+      Connection.stop(conn2)
+    end
+
+    test "user function can abort the transaction", %{conn: conn} do
+      Connection.command(conn, ["SET", "watch:key", "0"])
+
+      result =
+        Connection.watch_transaction(conn, ["watch:key"], fn c ->
+          {:ok, val} = Connection.command(c, ["GET", "watch:key"])
+
+          if String.to_integer(val) < 100 do
+            {:abort, :insufficient_balance}
+          else
+            [["DECRBY", "watch:key", "100"]]
+          end
+        end)
+
+      assert {:error, {:aborted, :insufficient_balance}} = result
+      # Key should be unchanged
+      assert {:ok, "0"} = Connection.command(conn, ["GET", "watch:key"])
+    end
+
+    test "works through the top-level Redis module", %{conn: conn} do
+      Redis.command(conn, ["SET", "watch:key", "hello"])
+
+      result =
+        Redis.watch_transaction(conn, ["watch:key"], fn c ->
+          {:ok, val} = Redis.command(c, ["GET", "watch:key"])
+          [["SET", "watch:key", val <> " world"]]
+        end)
+
+      assert {:ok, ["OK"]} = result
+      assert {:ok, "hello world"} = Redis.command(conn, ["GET", "watch:key"])
+    end
+  end
+end


### PR DESCRIPTION
Closes #27

## Summary

Adds `Redis.watch_transaction/4` for optimistic locking via WATCH/MULTI/EXEC.

## API

```elixir
Redis.watch_transaction(conn, ["balance"], fn conn ->
  {:ok, bal} = Redis.command(conn, ["GET", "balance"])
  new_bal = String.to_integer(bal) + 100
  [["SET", "balance", to_string(new_bal)]]
end)
```

**Options:**
- `:max_retries` - retry attempts on WATCH conflict (default: 3)
- `:timeout` - command timeout (default: 5000)

**Return values:**
- `{:ok, results}` - transaction committed
- `{:error, :watch_conflict}` - all retries exhausted
- `{:error, {:aborted, reason}}` - user function returned `{:abort, reason}`

## Tests

6 tests covering:
- Basic optimistic locking
- Multiple watched keys
- Automatic retry on concurrent modification
- Max retries exhaustion
- User-initiated abort
- Top-level `Redis` module delegation

## Test plan

- [ ] `mix test test/watch_transaction_test.exs` passes
- [ ] `mix credo --strict` clean
- [ ] `mix compile --warnings-as-errors` clean