### PR TITLE
feat: Streams Consumer GenServer

### DIFF
--- a/lib/redis/consumer.ex
+++ b/lib/redis/consumer.ex
@@ -1,0 +1,288 @@
+defmodule Redis.Consumer do
+  @moduledoc """
+  A GenServer for consuming Redis Streams via consumer groups.
+
+  Wraps `XREADGROUP` in a loop with automatic acknowledgement, pending
+  message recovery via `XAUTOCLAIM`, and consumer group creation.
+
+  ## Usage
+
+  Define a handler module:
+
+      defmodule MyApp.EventHandler do
+        @behaviour Redis.Consumer.Handler
+
+        @impl true
+        def handle_messages(messages, _metadata) do
+          for {stream, entries} <- messages, {id, fields} <- entries do
+            IO.puts("Got \#{id} from \#{stream}: \#{inspect(fields)}")
+          end
+
+          :ok
+        end
+      end
+
+  Start the consumer:
+
+      {:ok, consumer} = Redis.Consumer.start_link(
+        conn: conn,
+        stream: "events",
+        group: "workers",
+        consumer: "worker-1",
+        handler: MyApp.EventHandler
+      )
+
+  Or add to a supervision tree:
+
+      children = [
+        {Redis.Connection, port: 6379, name: :redis},
+        {Redis.Consumer,
+         conn: :redis,
+         stream: "events",
+         group: "workers",
+         consumer: "worker-1",
+         handler: MyApp.EventHandler}
+      ]
+
+  ## Options
+
+    * `:conn` (required) - Redis connection (pid or registered name)
+    * `:stream` (required) - stream key to consume from
+    * `:group` (required) - consumer group name
+    * `:consumer` (required) - consumer name within the group
+    * `:handler` (required) - module implementing `Redis.Consumer.Handler`
+    * `:count` - max entries per read (default: 10)
+    * `:block` - block timeout in ms for XREADGROUP (default: 5000)
+    * `:claim_interval` - ms between XAUTOCLAIM runs (default: 30_000)
+    * `:claim_min_idle` - min idle time in ms for XAUTOCLAIM (default: 60_000)
+    * `:name` - GenServer name registration
+
+  ## Message Recovery
+
+  On startup and periodically (every `:claim_interval` ms), the consumer
+  runs XAUTOCLAIM to reclaim messages that were delivered to other consumers
+  in the group but not acknowledged within `:claim_min_idle` ms. This handles
+  consumer crashes and restarts gracefully.
+  """
+
+  use GenServer
+
+  alias Redis.Commands.Stream
+  alias Redis.Connection
+
+  require Logger
+
+  defstruct [
+    :conn,
+    :stream,
+    :group,
+    :consumer,
+    :handler,
+    count: 10,
+    block: 5_000,
+    claim_interval: 30_000,
+    claim_min_idle: 60_000
+  ]
+
+  # -------------------------------------------------------------------
+  # Public API
+  # -------------------------------------------------------------------
+
+  def start_link(opts) do
+    {name, opts} = Keyword.pop(opts, :name)
+
+    if name do
+      GenServer.start_link(__MODULE__, opts, name: name)
+    else
+      GenServer.start_link(__MODULE__, opts)
+    end
+  end
+
+  @doc "Returns consumer info: stream, group, consumer name, handler."
+  @spec info(GenServer.server()) :: map()
+  def info(consumer), do: GenServer.call(consumer, :info)
+
+  @doc "Stops the consumer gracefully."
+  @spec stop(GenServer.server()) :: :ok
+  def stop(consumer), do: GenServer.stop(consumer, :normal)
+
+  # -------------------------------------------------------------------
+  # GenServer callbacks
+  # -------------------------------------------------------------------
+
+  @impl true
+  def init(opts) do
+    state = %__MODULE__{
+      conn: Keyword.fetch!(opts, :conn),
+      stream: Keyword.fetch!(opts, :stream),
+      group: Keyword.fetch!(opts, :group),
+      consumer: Keyword.fetch!(opts, :consumer),
+      handler: Keyword.fetch!(opts, :handler),
+      count: Keyword.get(opts, :count, 10),
+      block: Keyword.get(opts, :block, 5_000),
+      claim_interval: Keyword.get(opts, :claim_interval, 30_000),
+      claim_min_idle: Keyword.get(opts, :claim_min_idle, 60_000)
+    }
+
+    ensure_group(state)
+    schedule_claim(state)
+    send(self(), :poll)
+
+    {:ok, state}
+  end
+
+  @impl true
+  def handle_info(:poll, state) do
+    case read_messages(state) do
+      {:ok, messages} when messages != nil and messages != %{} and messages != [] ->
+        process_messages(state, normalize_messages(messages))
+
+      _ ->
+        :ok
+    end
+
+    send(self(), :poll)
+    {:noreply, state}
+  end
+
+  def handle_info(:claim, state) do
+    claim_pending(state)
+    schedule_claim(state)
+    {:noreply, state}
+  end
+
+  def handle_info(_msg, state), do: {:noreply, state}
+
+  @impl true
+  def handle_call(:info, _from, state) do
+    info = %{
+      stream: state.stream,
+      group: state.group,
+      consumer: state.consumer,
+      handler: state.handler
+    }
+
+    {:reply, info, state}
+  end
+
+  # -------------------------------------------------------------------
+  # Private
+  # -------------------------------------------------------------------
+
+  defp ensure_group(state) do
+    cmd = Stream.xgroup_create(state.stream, state.group, "0", mkstream: true)
+
+    case Connection.command(state.conn, cmd) do
+      {:ok, "OK"} ->
+        Logger.debug("Redis.Consumer: created group #{state.group} on #{state.stream}")
+
+      {:error, %Redis.Error{message: "BUSYGROUP" <> _}} ->
+        # Group already exists, that's fine
+        :ok
+
+      {:error, reason} ->
+        Logger.warning("Redis.Consumer: failed to create group: #{inspect(reason)}")
+    end
+  end
+
+  defp read_messages(state) do
+    cmd =
+      Stream.xreadgroup(state.group, state.consumer,
+        streams: [{state.stream, ">"}],
+        count: state.count,
+        block: state.block
+      )
+
+    Connection.command(state.conn, cmd)
+  end
+
+  defp process_messages(state, messages) do
+    ids = extract_ids(messages)
+
+    case state.handler.handle_messages(messages, %{stream: state.stream, group: state.group}) do
+      :ok ->
+        ack_messages(state, ids)
+
+      {:ok, ack_ids} when is_list(ack_ids) ->
+        ack_messages(state, ack_ids)
+
+      {:error, reason} ->
+        Logger.warning(
+          "Redis.Consumer: handler error for #{length(ids)} messages: #{inspect(reason)}"
+        )
+    end
+  rescue
+    e ->
+      Logger.error(
+        "Redis.Consumer: handler crashed: #{Exception.format(:error, e, __STACKTRACE__)}"
+      )
+  end
+
+  defp ack_messages(_state, []), do: :ok
+
+  defp ack_messages(state, ids) do
+    cmd = Stream.xack(state.stream, state.group, ids)
+
+    case Connection.command(state.conn, cmd) do
+      {:ok, _count} -> :ok
+      {:error, reason} -> Logger.warning("Redis.Consumer: XACK failed: #{inspect(reason)}")
+    end
+  end
+
+  defp claim_pending(state) do
+    cmd =
+      Stream.xautoclaim(
+        state.stream,
+        state.group,
+        state.consumer,
+        state.claim_min_idle,
+        "0-0",
+        count: state.count
+      )
+
+    case Connection.command(state.conn, cmd) do
+      {:ok, [_cursor, messages | _]} when messages != [] ->
+        Logger.debug("Redis.Consumer: claimed #{length(messages)} pending messages")
+        ids = Enum.map(messages, fn [id | _] -> id end)
+        process_claimed(state, messages, ids)
+
+      _ ->
+        :ok
+    end
+  end
+
+  defp process_claimed(state, messages, ids) do
+    # Wrap claimed messages in the same format as XREADGROUP
+    wrapped = [[state.stream, messages]]
+
+    case state.handler.handle_messages(wrapped, %{
+           stream: state.stream,
+           group: state.group,
+           claimed: true
+         }) do
+      :ok -> ack_messages(state, ids)
+      {:ok, ack_ids} when is_list(ack_ids) -> ack_messages(state, ack_ids)
+      {:error, _} -> :ok
+    end
+  rescue
+    _ -> :ok
+  end
+
+  # RESP3 returns a map %{"stream" => entries}, RESP2 returns [["stream", entries]].
+  # Normalize to [[stream, entries]] for consistent handling.
+  defp normalize_messages(messages) when is_map(messages) do
+    Enum.map(messages, fn {stream, entries} -> [stream, entries] end)
+  end
+
+  defp normalize_messages(messages) when is_list(messages), do: messages
+
+  defp extract_ids(messages) do
+    for [_stream, entries] <- messages,
+        [id | _] <- entries,
+        do: id
+  end
+
+  defp schedule_claim(state) do
+    Process.send_after(self(), :claim, state.claim_interval)
+  end
+end

--- a/lib/redis/consumer/handler.ex
+++ b/lib/redis/consumer/handler.ex
@@ -1,0 +1,45 @@
+defmodule Redis.Consumer.Handler do
+  @moduledoc """
+  Behaviour for handling messages from a Redis Streams consumer group.
+
+  ## Example
+
+      defmodule MyApp.EventHandler do
+        @behaviour Redis.Consumer.Handler
+
+        @impl true
+        def handle_messages(messages, metadata) do
+          for {stream, entries} <- messages, {id, fields} <- entries do
+            IO.puts("[\#{stream}] \#{id}: \#{inspect(fields)}")
+          end
+
+          :ok
+        end
+      end
+
+  ## Return Values
+
+    * `:ok` - all messages processed successfully, acknowledge all
+    * `{:ok, ids}` - selectively acknowledge only the given message IDs
+    * `{:error, reason}` - processing failed, messages will NOT be acknowledged
+      and will be redelivered on the next XAUTOCLAIM cycle
+  """
+
+  @type message_id :: String.t()
+  @type field :: String.t()
+  @type entry :: {message_id(), [field()]}
+  @type stream_messages :: {String.t(), [entry()]}
+  @type metadata :: map()
+
+  @doc """
+  Called when messages are received from the stream.
+
+  `messages` is a list of `{stream_key, entries}` tuples where each entry
+  is `{message_id, [field1, value1, field2, value2, ...]}`.
+
+  `metadata` contains `:stream`, `:group`, and optionally `:claimed` (true
+  when messages were recovered via XAUTOCLAIM).
+  """
+  @callback handle_messages([stream_messages()], metadata()) ::
+              :ok | {:ok, [message_id()]} | {:error, term()}
+end

--- a/test/consumer_test.exs
+++ b/test/consumer_test.exs
@@ -1,0 +1,269 @@
+defmodule Redis.ConsumerTest do
+  use ExUnit.Case, async: false
+
+  alias Redis.Connection
+  alias Redis.Consumer
+
+  # Uses redis-server on port 6398 from test_helper.exs
+
+  defmodule TestHandler do
+    @behaviour Redis.Consumer.Handler
+
+    @impl true
+    def handle_messages(messages, metadata) do
+      # Send messages to the test process stored in the process dictionary
+      test_pid = :persistent_term.get(:consumer_test_pid)
+
+      for [stream, entries] <- messages, [id | fields] <- entries do
+        send(test_pid, {:consumed, stream, id, fields, metadata})
+      end
+
+      :ok
+    end
+  end
+
+  defmodule ErrorHandler do
+    @behaviour Redis.Consumer.Handler
+
+    @impl true
+    def handle_messages(_messages, _metadata) do
+      {:error, :simulated_failure}
+    end
+  end
+
+  defmodule SelectiveAckHandler do
+    @behaviour Redis.Consumer.Handler
+
+    @impl true
+    def handle_messages(messages, _metadata) do
+      # Only ack messages with "important" field
+      ids =
+        for [_stream, entries] <- messages,
+            [id | fields] <- entries,
+            "important" in fields,
+            do: id
+
+      {:ok, ids}
+    end
+  end
+
+  setup do
+    {:ok, conn} = Connection.start_link(port: 6398)
+    :persistent_term.put(:consumer_test_pid, self())
+
+    stream = "test:stream:#{:erlang.unique_integer([:positive])}"
+    group = "test_group"
+
+    on_exit(fn ->
+      :persistent_term.erase(:consumer_test_pid)
+
+      case Connection.start_link(port: 6398) do
+        {:ok, cleanup} ->
+          Connection.command(cleanup, ["DEL", stream])
+          Connection.stop(cleanup)
+
+        _ ->
+          :ok
+      end
+    end)
+
+    {:ok, conn: conn, stream: stream, group: group}
+  end
+
+  describe "consumer lifecycle" do
+    test "starts, creates group, and consumes messages", %{
+      conn: conn,
+      stream: stream,
+      group: group
+    } do
+      # Add some messages before starting the consumer
+      Connection.command(conn, ["XADD", stream, "*", "event", "click", "url", "/home"])
+      Connection.command(conn, ["XADD", stream, "*", "event", "view", "url", "/about"])
+
+      {:ok, consumer} =
+        Consumer.start_link(
+          conn: conn,
+          stream: stream,
+          group: group,
+          consumer: "worker-1",
+          handler: TestHandler,
+          block: 100,
+          count: 10
+        )
+
+      # Wait for the consumer to process messages
+      assert_receive {:consumed, ^stream, _id1, fields1, _meta}, 2000
+      assert List.flatten(fields1) == ["event", "click", "url", "/home"]
+      assert_receive {:consumed, ^stream, _id2, fields2, _meta}, 2000
+      assert List.flatten(fields2) == ["event", "view", "url", "/about"]
+
+      Consumer.stop(consumer)
+    end
+
+    test "consumes messages added after startup", %{conn: conn, stream: stream, group: group} do
+      {:ok, consumer} =
+        Consumer.start_link(
+          conn: conn,
+          stream: stream,
+          group: group,
+          consumer: "worker-1",
+          handler: TestHandler,
+          block: 100
+        )
+
+      # Small delay to let consumer start polling
+      Process.sleep(200)
+
+      # Add message after consumer is running
+      Connection.command(conn, ["XADD", stream, "*", "type", "new_event"])
+
+      assert_receive {:consumed, ^stream, _id, fields, _meta}, 2000
+      assert List.flatten(fields) == ["type", "new_event"]
+
+      Consumer.stop(consumer)
+    end
+
+    test "info returns consumer metadata", %{conn: conn, stream: stream, group: group} do
+      {:ok, consumer} =
+        Consumer.start_link(
+          conn: conn,
+          stream: stream,
+          group: group,
+          consumer: "worker-1",
+          handler: TestHandler,
+          block: 100
+        )
+
+      info = Consumer.info(consumer)
+      assert info.stream == stream
+      assert info.group == group
+      assert info.consumer == "worker-1"
+      assert info.handler == TestHandler
+
+      Consumer.stop(consumer)
+    end
+  end
+
+  describe "acknowledgement" do
+    test "messages are acknowledged after successful processing", %{
+      conn: conn,
+      stream: stream,
+      group: group
+    } do
+      Connection.command(conn, ["XADD", stream, "*", "data", "value"])
+
+      {:ok, consumer} =
+        Consumer.start_link(
+          conn: conn,
+          stream: stream,
+          group: group,
+          consumer: "worker-1",
+          handler: TestHandler,
+          block: 100
+        )
+
+      assert_receive {:consumed, _, _, _, _}, 2000
+      Process.sleep(100)
+
+      # Check that there are no pending messages
+      {:ok, pending} = Connection.command(conn, ["XPENDING", stream, group, "-", "+", "10"])
+      assert pending == [] or pending == nil
+
+      Consumer.stop(consumer)
+    end
+
+    test "selective ack only acknowledges returned ids", %{
+      conn: conn,
+      stream: stream,
+      group: group
+    } do
+      Connection.command(conn, ["XADD", stream, "*", "data", "normal"])
+      Connection.command(conn, ["XADD", stream, "*", "important", "true", "data", "critical"])
+
+      {:ok, consumer} =
+        Consumer.start_link(
+          conn: conn,
+          stream: stream,
+          group: group,
+          consumer: "worker-1",
+          handler: SelectiveAckHandler,
+          block: 100
+        )
+
+      Process.sleep(500)
+
+      # The "normal" message should still be pending (not acked)
+      {:ok, pending} = Connection.command(conn, ["XPENDING", stream, group, "-", "+", "10"])
+      # At least one message should be pending (the non-important one)
+      assert [_ | _] = pending
+
+      Consumer.stop(consumer)
+    end
+  end
+
+  describe "error handling" do
+    test "handler errors don't crash the consumer", %{conn: conn, stream: stream, group: group} do
+      Connection.command(conn, ["XADD", stream, "*", "data", "will_fail"])
+
+      {:ok, consumer} =
+        Consumer.start_link(
+          conn: conn,
+          stream: stream,
+          group: group,
+          consumer: "worker-1",
+          handler: ErrorHandler,
+          block: 100
+        )
+
+      # Consumer should still be alive after handler returns error
+      Process.sleep(500)
+      assert Process.alive?(consumer)
+
+      Consumer.stop(consumer)
+    end
+  end
+
+  describe "group creation" do
+    test "creates group with MKSTREAM if stream doesn't exist", %{
+      conn: conn,
+      stream: stream,
+      group: group
+    } do
+      # Stream doesn't exist yet -- consumer should create it
+      {:ok, consumer} =
+        Consumer.start_link(
+          conn: conn,
+          stream: stream,
+          group: group,
+          consumer: "worker-1",
+          handler: TestHandler,
+          block: 100
+        )
+
+      # Verify the stream and group exist
+      {:ok, groups} = Connection.command(conn, ["XINFO", "GROUPS", stream])
+      assert is_list(groups)
+
+      Consumer.stop(consumer)
+    end
+
+    test "handles already existing group gracefully", %{conn: conn, stream: stream, group: group} do
+      # Pre-create the group
+      Connection.command(conn, ["XGROUP", "CREATE", stream, group, "0", "MKSTREAM"])
+
+      # Consumer should start without error
+      {:ok, consumer} =
+        Consumer.start_link(
+          conn: conn,
+          stream: stream,
+          group: group,
+          consumer: "worker-1",
+          handler: TestHandler,
+          block: 100
+        )
+
+      assert Process.alive?(consumer)
+      Consumer.stop(consumer)
+    end
+  end
+end


### PR DESCRIPTION
Closes #29

## Summary

High-level GenServer for Redis Streams consumer groups via `Redis.Consumer`.

```elixir
Redis.Consumer.start_link(
  conn: conn,
  stream: "events",
  group: "workers",
  consumer: "worker-1",
  handler: MyApp.EventHandler
)
```

## Features

- `Redis.Consumer.Handler` behaviour with `handle_messages/2` callback
- XREADGROUP polling loop with configurable BLOCK timeout
- Automatic XACK on success, selective ack (return specific IDs)
- XAUTOCLAIM for pending message recovery (configurable interval/idle time)
- XGROUP CREATE with MKSTREAM on startup
- RESP3 response normalization (map -> list)
- Handler errors/crashes don't kill the consumer

## Options

`:conn`, `:stream`, `:group`, `:consumer`, `:handler` (required)
`:count`, `:block`, `:claim_interval`, `:claim_min_idle`, `:name` (optional)

## Tests

8 tests: lifecycle, message consumption, acknowledgement, selective ack, error handling, group creation

## Test plan

- [ ] `mix test test/consumer_test.exs` passes
- [ ] `mix credo --strict` clean