### PR TITLE
fix: cluster topology discovery works correctly after failover

### DIFF
--- a/test/cluster_failover_test.exs
+++ b/test/cluster_failover_test.exs
@@ -232,7 +232,9 @@ defmodule Redis.ClusterFailoverTest do
   # Find the replica of a dead master (master already killed)
   defp find_replica_of_dead(cluster_srv, killed, dead_port) do
     surviving = RedisServerWrapper.Cluster.nodes(cluster_srv) |> Enum.reject(&(&1 == killed))
-    {:ok, cn} = Server.run(hd(surviving), ["CLUSTER", "NODES"])
+
+    # Query CLUSTER NODES from any reachable surviving node
+    cn = get_cluster_nodes_from_any(surviving)
 
     dead_id =
       cn
@@ -241,7 +243,6 @@ defmodule Redis.ClusterFailoverTest do
         if String.contains?(line, ":#{dead_port}@"), do: line |> String.split() |> hd()
       end)
 
-    # Find slave line referencing dead master ID
     replica_port =
       cn
       |> String.split("\n", trim: true)
@@ -250,10 +251,7 @@ defmodule Redis.ClusterFailoverTest do
 
         if length(parts) >= 4 and String.contains?(Enum.at(parts, 2), "slave") and
              Enum.at(parts, 3) == dead_id do
-          addr = Enum.at(parts, 1)
-          [host_port | _] = String.split(addr, "@")
-          [_host, port_str] = String.split(host_port, ":")
-          String.to_integer(port_str)
+          Enum.at(parts, 1) |> parse_port_from_addr()
         end
       end)
 
@@ -264,6 +262,25 @@ defmodule Redis.ClusterFailoverTest do
         :exit, _ -> false
       end
     end) || raise "Could not find replica of dead master on port #{dead_port}"
+  end
+
+  defp get_cluster_nodes_from_any(nodes) do
+    Enum.find_value(nodes, fn n ->
+      try do
+        case Server.run(n, ["CLUSTER", "NODES"]) do
+          {:ok, output} -> output
+          _ -> nil
+        end
+      catch
+        :exit, _ -> nil
+      end
+    end) || raise "No reachable nodes"
+  end
+
+  defp parse_port_from_addr(addr) do
+    [host_port | _] = String.split(addr, "@")
+    [_host, port_str] = String.split(host_port, ":")
+    String.to_integer(port_str)
   end
 
   defp slot_in_ranges?(slot, ranges) do


### PR DESCRIPTION
Closes #57

## Summary

Investigation showed `Topology.parse_slots` handles the RESP3 CLUSTER SLOTS response correctly after failover -- the promoted replica's address is properly returned and parsed.

The reported issue was actually a test helper bug: `find_replica_of_dead` queried only `hd(surviving)` which could be a node killed by a previous test in the shared `setup_all`. Fixed to try all surviving nodes until one responds.

## What was verified

- CLUSTER SLOTS returns the promoted replica's address after `CLUSTER FAILOVER FORCE`
- `Topology.parse_slots/1` correctly parses the RESP3 format (lists with 4-element node entries including node ID and empty map)
- `refresh_from_slots` drops stale connections and connects to new masters
- All 4 cluster failover tests pass reliably

## Test plan

- [x] `REDIS_CLUSTER_FAILOVER=true mix test test/cluster_failover_test.exs` -- 4 tests, 0 failures
- [x] `mix credo --strict` -- no issues