### PR TITLE
docs: audit cleanup -- README, moduledoc, contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,82 @@
+# Contributing
+
+Contributions are welcome! Here's how to get started.
+
+## Setup
+
+1. Fork and clone the repo
+2. Install dependencies: `mix deps.get`
+3. Install Redis (7+ recommended, 8+ for JSON/Search features)
+4. Run tests: `mix test`
+
+You'll need `redis-server` on your PATH for the test suite. The tests use
+[redis_server_wrapper](https://hex.pm/packages/redis_server_wrapper) to
+manage Redis instances on custom ports automatically.
+
+## Running Tests
+
+```bash
+# Unit and integration tests (starts Redis automatically)
+mix test
+
+# Include Redis Stack tests (JSON, Search -- needs redis-stack-server)
+REDIS_STACK=true mix test
+
+# Include cluster failover tests (slower, starts a 6-node cluster)
+REDIS_CLUSTER_FAILOVER=true mix test
+
+# Include sentinel tests (needs sentinel topology)
+REDIS_SENTINEL=true mix test
+```
+
+## Code Quality
+
+Before submitting a PR, ensure:
+
+```bash
+mix format --check-formatted
+mix compile --warnings-as-errors
+mix credo --strict
+mix dialyzer
+mix test
+```
+
+All of these run in CI.
+
+## Pull Requests
+
+- One PR per issue/feature
+- Reference the issue with `Closes #N` in the PR body
+- Use [conventional commits](https://www.conventionalcommits.org/):
+  `feat:`, `fix:`, `docs:`, `test:`, `chore:`, `refactor:`
+- Keep PRs focused -- separate unrelated changes into separate PRs
+- Add tests for new features
+- Update documentation for public API changes
+
+## Architecture
+
+The codebase is organized by concern:
+
+```
+lib/redis/
+  connection/     # TCP/TLS connection, pooling
+  cluster/        # Cluster routing, topology, failover
+  sentinel/       # Sentinel discovery, monitoring
+  pubsub/         # Pub/sub, sharded pub/sub
+  cache/          # Client-side caching with ETS
+  resilience/     # Circuit breaker, retry, bulkhead, coalesce
+  commands/       # 21 command builder modules (pure functions)
+  consumer.ex     # Streams consumer group GenServer
+  phoenix_pubsub.ex  # Phoenix.PubSub adapter
+  protocol/       # RESP2/RESP3 encode/decode
+  script.ex       # Lua script helper
+  telemetry.ex    # Telemetry events
+  uri.ex          # Redis URI parser
+```
+
+Command builders in `lib/redis/commands/` are pure functions that return
+command lists. They have no connection logic and can be tested without Redis.
+
+## Questions?
+
+Open an issue or start a discussion. We're happy to help.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ RESP3 native. Cluster-aware. Client-side caching. Resilience built in. Zero requ
 ```elixir
 def deps do
   [
-    {:redis_client_ex, "~> 0.1"}
+    {:redis_client_ex, "~> 0.3"}
   ]
 end
 ```
@@ -80,6 +80,19 @@ Redis.Connection.Pool.command(pool, ["GET", "key"])
 ])
 ```
 
+## Optimistic Locking (WATCH)
+
+```elixir
+Redis.watch_transaction(conn, ["balance"], fn conn ->
+  {:ok, bal} = Redis.command(conn, ["GET", "balance"])
+  new_bal = String.to_integer(bal) + 100
+  [["SET", "balance", to_string(new_bal)]]
+end)
+```
+
+Watches keys, calls your function to read and compute commands, then
+executes in MULTI/EXEC. Automatically retries on conflict (default 3 attempts).
+
 ## Command Builders
 
 Pure functions that return command lists. Use them with any connection type.
@@ -124,6 +137,13 @@ Redis.Cluster.pipeline(cluster, [
   ["GET", "key1"],
 ])
 #=> {:ok, ["OK", "OK", "a"]}
+
+# Transactions require same-slot keys (use hash tags)
+Redis.Cluster.transaction(cluster, [
+  ["SET", "{user:1}.name", "Alice"],
+  ["SET", "{user:1}.email", "alice@example.com"]
+])
+#=> {:ok, ["OK", "OK"]}
 ```
 
 ## Sentinel
@@ -151,6 +171,22 @@ receive do
     IO.puts("Got: #{payload}")
 end
 ```
+
+## Phoenix.PubSub Adapter
+
+Drop-in Redis adapter for Phoenix.PubSub. Enables cross-node broadcasting
+for Phoenix, LiveView, and any PubSub-based feature.
+
+```elixir
+children = [
+  {Phoenix.PubSub,
+   name: MyApp.PubSub,
+   adapter: Redis.PhoenixPubSub,
+   redis_opts: [host: "localhost", port: 6379]}
+]
+```
+
+Requires `phoenix_pubsub` (optional dependency).
 
 ## Streams Consumer
 
@@ -227,9 +263,12 @@ Redis.Resilience.command(conn, ["GET", "key"])
 ## Features
 
 - **RESP3 native** with RESP2 fallback for older servers
-- **Cluster** with topology discovery, hash slot routing, MOVED/ASK redirects, cross-slot pipeline splitting
+- **Cluster** with topology discovery, hash slot routing, MOVED/ASK redirects, cross-slot pipeline splitting, transaction validation
 - **Sentinel** with master resolution, role verification, proactive failover via `+switch-master`
 - **Pub/Sub** with pattern subscriptions, sharded pub/sub (Redis 7+)
+- **Phoenix.PubSub adapter** for cross-node broadcasting (optional dep)
+- **Streams Consumer** with consumer groups, auto-ack, and pending message recovery
+- **WATCH transactions** with automatic retry on conflict
 - **Client-side caching** via RESP3 server-assisted invalidation + ETS
 - **Connection pool** with round-robin/random dispatch
 - **Resilience** patterns: circuit breaker, retry with backoff, request coalescing, bulkhead

--- a/lib/redis.ex
+++ b/lib/redis.ex
@@ -2,10 +2,24 @@ defmodule Redis do
   @moduledoc """
   Modern, full-featured Redis client for Elixir.
 
+  This module provides the top-level API for single-connection usage.
+  For other deployment modes and features, see:
+
+    * `Redis.Connection` - single connection with full options
+    * `Redis.Connection.Pool` - connection pooling
+    * `Redis.Cluster` - cluster-aware client with slot routing
+    * `Redis.Sentinel` - sentinel-aware client with failover
+    * `Redis.PubSub` - pub/sub subscriptions
+    * `Redis.PhoenixPubSub` - Phoenix.PubSub adapter
+    * `Redis.Cache` - client-side caching with ETS
+    * `Redis.Consumer` - streams consumer group GenServer
+    * `Redis.Resilience` - composed retry, circuit breaker, bulkhead
+    * `Redis.Script` - Lua script execution with SHA caching
+    * `Redis.Commands` - 21 command builder modules
+
   ## Quick Start
 
       {:ok, conn} = Redis.start_link()
-      {:ok, conn} = Redis.start_link("redis://:secret@localhost:6380/2")
       {:ok, "OK"} = Redis.command(conn, ["SET", "key", "value"])
       {:ok, "value"} = Redis.command(conn, ["GET", "key"])
 
@@ -17,22 +31,21 @@ defmodule Redis do
         ["MGET", "a", "b"]
       ])
 
-  ## Fire-and-Forget
+  ## Transactions
 
-      :ok = Redis.noreply_command(conn, ["INCR", "counter"])
-      :ok = Redis.noreply_pipeline(conn, [["SET", "a", "1"], ["SET", "b", "2"]])
+      {:ok, [1, 2, 3]} = Redis.transaction(conn, [
+        ["INCR", "counter"],
+        ["INCR", "counter"],
+        ["INCR", "counter"]
+      ])
 
-  ## Cluster
+  ## Optimistic Locking
 
-      {:ok, cluster} = Redis.Cluster.start_link(nodes: [{"127.0.0.1", 7000}])
-      {:ok, "value"} = Redis.Cluster.command(cluster, ["GET", "key"])
-
-  ## Sentinel
-
-      {:ok, conn} = Redis.Sentinel.start_link(
-        sentinels: ["sentinel1:26379"],
-        group: "mymaster"
-      )
+      Redis.watch_transaction(conn, ["balance"], fn conn ->
+        {:ok, bal} = Redis.command(conn, ["GET", "balance"])
+        new_bal = String.to_integer(bal) + 100
+        [["SET", "balance", to_string(new_bal)]]
+      end)
   """
 
   alias Redis.Connection


### PR DESCRIPTION
Closes #40

## Summary

Documentation audit found and fixed:

**README:**
- Added missing WATCH transactions section
- Added missing Phoenix.PubSub adapter section  
- Added cluster transactions example
- Updated Features list with new capabilities (Phoenix.PubSub, Streams Consumer, WATCH, cluster transactions)
- Fixed install version from `~> 0.1` to `~> 0.3`

**lib/redis.ex moduledoc:**
- Added full module ecosystem reference (Connection, Pool, Cluster, Sentinel, PubSub, PhoenixPubSub, Cache, Consumer, Resilience, Script, Commands)
- Added transactions and optimistic locking examples

**CONTRIBUTING.md (new):**
- Setup, test commands, code quality checklist
- PR guidelines with conventional commits
- Architecture overview

## Test plan

- [x] `mix compile --warnings-as-errors`
- [x] `mix credo --strict` -- no issues