### PR TITLE
feat: high-level Redis Search API (Meilisearch-inspired)

### DIFF
--- a/lib/redis/search.ex
+++ b/lib/redis/search.ex
@@ -1,0 +1,557 @@
+defmodule Redis.Search do
+  @moduledoc """
+  High-level search API for Redis, inspired by Meilisearch.
+
+  Wraps the RediSearch `FT.*` commands with an Elixir-friendly interface:
+  keyword-based schemas, map-based documents, Elixir filter expressions
+  instead of raw query strings, and parsed result structs.
+
+  For raw command access, see `Redis.Commands.Search`.
+
+  ## Quick Start
+
+      # Create an index
+      Redis.Search.create_index(conn, "movies",
+        prefix: "movie:",
+        fields: [
+          title: :text,
+          year: {:numeric, sortable: true},
+          genres: :tag
+        ]
+      )
+
+      # Add documents as maps
+      Redis.Search.add(conn, "movies", "movie:1", %{
+        title: "The Dark Knight",
+        year: 2008,
+        genres: "action,thriller"
+      })
+
+      # Search with Elixir filters
+      Redis.Search.find(conn, "movies", "dark knight",
+        where: [year: {:gt, 2000}, genres: "action"],
+        sort: {:year, :desc},
+        limit: 10
+      )
+      #=> {:ok, %Redis.Search.Result{total: 1, results: [%{id: "movie:1", ...}]}}
+
+  ## Filter Syntax
+
+  The `:where` option accepts a keyword list compiled to RediSearch query syntax:
+
+    * `field: "value"` -- text match (`@field:value`)
+    * `field: {:match, "hello world"}` -- phrase match (`@field:(hello world)`)
+    * `field: {:gt, n}` -- greater than (`@field:[(n +inf]`)
+    * `field: {:gte, n}` -- greater than or equal (`@field:[n +inf]`)
+    * `field: {:lt, n}` -- less than (`@field:[-inf (n]`)
+    * `field: {:lte, n}` -- less than or equal (`@field:[-inf n]`)
+    * `field: {:between, min, max}` -- range (`@field:[min max]`)
+    * `field: {:tag, "val"}` -- exact tag (`@field:{val}`)
+    * `field: {:any, ["a", "b"]}` -- tag OR (`@field:{a|b}`)
+
+  ## Options
+
+    * `:where` -- filter keyword list (see above)
+    * `:sort` -- `{field, :asc | :desc}`
+    * `:limit` -- max results (integer) or `{offset, count}`
+    * `:return` -- list of fields to return
+    * `:nocontent` -- return only IDs (boolean)
+    * `:dialect` -- RediSearch query dialect version
+    * `:coerce` -- auto-coerce numeric strings (default: true)
+  """
+
+  alias Redis.Commands.Search, as: Cmd
+  alias Redis.Connection
+
+  defmodule Result do
+    @moduledoc """
+    Parsed search or aggregation result.
+
+    Fields:
+      * `:total` -- total number of matching documents
+      * `:results` -- list of result maps with `:id` and field data
+    """
+    defstruct total: 0, results: []
+
+    @type t :: %__MODULE__{
+            total: non_neg_integer(),
+            results: [map()]
+          }
+  end
+
+  # -------------------------------------------------------------------
+  # Index Management
+  # -------------------------------------------------------------------
+
+  @doc """
+  Creates a search index.
+
+  Fields are specified as a keyword list:
+
+      Redis.Search.create_index(conn, "idx", fields: [name: :text, age: :numeric])
+      Redis.Search.create_index(conn, "idx",
+        on: :json,
+        prefix: "doc:",
+        fields: [
+          title: :text,
+          score: {:numeric, sortable: true},
+          tags: :tag
+        ]
+      )
+
+  ## Options
+
+    * `:fields` (required) -- keyword list of `{name, type}` or `{name, {type, opts...}}`
+    * `:on` -- `:hash` (default) or `:json`
+    * `:prefix` -- key prefix string or list
+    * `:stopwords` -- list of stopwords or `0` for none
+    * `:language` -- default language
+  """
+  def create_index(conn, index, opts) do
+    type = Keyword.get(opts, :on, :hash)
+    fields = Keyword.fetch!(opts, :fields)
+
+    schema = build_schema(fields, type)
+
+    cmd_opts =
+      opts
+      |> Keyword.drop([:fields, :on])
+      |> Keyword.put(:schema, schema)
+
+    case Connection.command(conn, Cmd.create(index, type, cmd_opts)) do
+      {:ok, "OK"} -> :ok
+      {:error, _} = err -> err
+    end
+  end
+
+  @doc "Drops a search index. Pass `dd: true` to also delete indexed documents."
+  def drop_index(conn, index, opts \\ []) do
+    case Connection.command(conn, Cmd.dropindex(index, opts)) do
+      {:ok, "OK"} -> :ok
+      {:error, _} = err -> err
+    end
+  end
+
+  @doc "Returns index info as a map."
+  def index_info(conn, index) do
+    Connection.command(conn, Cmd.info(index))
+  end
+
+  # -------------------------------------------------------------------
+  # Document Ingestion
+  # -------------------------------------------------------------------
+
+  @doc """
+  Adds a document to an index.
+
+  Auto-detects hash vs JSON based on the index type. Pass `:on` to
+  override if the index hasn't been inspected yet.
+
+      Redis.Search.add(conn, "movies", "movie:1", %{
+        title: "Inception",
+        year: 2010,
+        genres: "sci-fi,thriller"
+      })
+  """
+  def add(conn, _index, key, doc, opts \\ []) when is_map(doc) do
+    type = Keyword.get(opts, :on, :hash)
+
+    case type do
+      :json ->
+        json = Jason.encode!(doc)
+        Connection.command(conn, ["JSON.SET", key, "$", json])
+
+      :hash ->
+        fields = Enum.flat_map(doc, fn {k, v} -> [to_string(k), to_string(v)] end)
+        Connection.command(conn, ["HSET", key | fields])
+    end
+  end
+
+  @doc """
+  Adds multiple documents via pipeline.
+
+      Redis.Search.add_many(conn, "movies", [
+        {"movie:1", %{title: "Inception", year: 2010}},
+        {"movie:2", %{title: "Interstellar", year: 2014}}
+      ])
+  """
+  def add_many(conn, _index, docs, opts \\ []) when is_list(docs) do
+    type = Keyword.get(opts, :on, :hash)
+
+    commands =
+      Enum.map(docs, fn {key, doc} ->
+        case type do
+          :json ->
+            ["JSON.SET", key, "$", Jason.encode!(doc)]
+
+          :hash ->
+            fields = Enum.flat_map(doc, fn {k, v} -> [to_string(k), to_string(v)] end)
+            ["HSET", key | fields]
+        end
+      end)
+
+    Connection.pipeline(conn, commands)
+  end
+
+  # -------------------------------------------------------------------
+  # Search
+  # -------------------------------------------------------------------
+
+  @doc """
+  Searches an index with Elixir-friendly filters.
+
+      # Simple full-text search
+      Redis.Search.find(conn, "movies", "dark knight")
+
+      # With filters
+      Redis.Search.find(conn, "movies", "batman",
+        where: [year: {:gt, 2000}, genres: {:tag, "action"}],
+        sort: {:year, :desc},
+        limit: 10,
+        return: [:title, :year]
+      )
+
+  See module docs for the full filter syntax.
+  """
+  def find(conn, index, query \\ "*", opts \\ []) do
+    {where, opts} = Keyword.pop(opts, :where, [])
+    {coerce, opts} = Keyword.pop(opts, :coerce, true)
+
+    full_query = build_query(query, where)
+    cmd_opts = translate_search_opts(opts)
+
+    case Connection.command(conn, Cmd.search(index, full_query, cmd_opts)) do
+      {:ok, raw} -> {:ok, parse_search_result(raw, coerce)}
+      {:error, _} = err -> err
+    end
+  end
+
+  # -------------------------------------------------------------------
+  # Aggregation
+  # -------------------------------------------------------------------
+
+  @doc """
+  Runs an aggregation query.
+
+      Redis.Search.aggregate(conn, "movies",
+        group_by: :genres,
+        reduce: [count: "total"],
+        sort: {:total, :desc},
+        limit: 10
+      )
+
+      # Multiple reducers
+      Redis.Search.aggregate(conn, "movies",
+        group_by: [:city],
+        reduce: [
+          count: "total",
+          avg: {:score, "avg_score"}
+        ]
+      )
+
+  ## Reducers
+
+    * `count: "alias"` -- COUNT
+    * `sum: {:field, "alias"}` -- SUM
+    * `avg: {:field, "alias"}` -- AVG
+    * `min: {:field, "alias"}` -- MIN
+    * `max: {:field, "alias"}` -- MAX
+  """
+  def aggregate(conn, index, opts \\ []) do
+    {where, opts} = Keyword.pop(opts, :where, [])
+    {group_by, opts} = Keyword.pop(opts, :group_by)
+    {reduce, opts} = Keyword.pop(opts, :reduce, [])
+    {sort, opts} = Keyword.pop(opts, :sort)
+    {limit, opts} = Keyword.pop(opts, :limit)
+    {coerce, opts} = Keyword.pop(opts, :coerce, true)
+    {dialect, _opts} = Keyword.pop(opts, :dialect)
+
+    query = build_query("*", where)
+
+    cmd_opts =
+      []
+      |> maybe_add_groupby(group_by, reduce)
+      |> maybe_add_agg_sort(sort)
+      |> maybe_add_limit(limit)
+      |> maybe_add_dialect(dialect)
+
+    case Connection.command(conn, Cmd.aggregate(index, query, cmd_opts)) do
+      {:ok, raw} -> {:ok, parse_aggregate_result(raw, coerce)}
+      {:error, _} = err -> err
+    end
+  end
+
+  # -------------------------------------------------------------------
+  # Query Builder
+  # -------------------------------------------------------------------
+
+  defp build_query(base, []), do: base
+
+  defp build_query(base, filters) do
+    filter_str = Enum.map_join(filters, " ", &compile_filter/1)
+
+    case base do
+      "*" -> filter_str
+      _ -> "#{base} #{filter_str}"
+    end
+  end
+
+  defp compile_filter({field, value}) when is_binary(value) do
+    "@#{field}:#{value}"
+  end
+
+  defp compile_filter({field, {:match, phrase}}) do
+    "@#{field}:(#{phrase})"
+  end
+
+  defp compile_filter({field, {:gt, n}}) do
+    "@#{field}:[(#{n} +inf]"
+  end
+
+  defp compile_filter({field, {:gte, n}}) do
+    "@#{field}:[#{n} +inf]"
+  end
+
+  defp compile_filter({field, {:lt, n}}) do
+    "@#{field}:[-inf (#{n}]"
+  end
+
+  defp compile_filter({field, {:lte, n}}) do
+    "@#{field}:[-inf #{n}]"
+  end
+
+  defp compile_filter({field, {:between, min, max}}) do
+    "@#{field}:[#{min} #{max}]"
+  end
+
+  defp compile_filter({field, {:tag, value}}) when is_binary(value) do
+    "@#{field}:{#{value}}"
+  end
+
+  defp compile_filter({field, {:any, values}}) when is_list(values) do
+    joined = Enum.join(values, "|")
+    "@#{field}:{#{joined}}"
+  end
+
+  # -------------------------------------------------------------------
+  # Schema Builder
+  # -------------------------------------------------------------------
+
+  defp build_schema(fields, type) do
+    Enum.map(fields, fn {name, type_spec} ->
+      {field_name, field_type, field_opts} = parse_field_spec(name, type_spec, type)
+      build_field_tuple(field_name, field_type, field_opts)
+    end)
+  end
+
+  defp parse_field_spec(name, type, index_type) when is_atom(type) do
+    field_name = field_path(name, index_type)
+    {field_name, type, []}
+  end
+
+  defp parse_field_spec(name, {type, opts}, index_type) when is_atom(type) and is_list(opts) do
+    field_name = field_path(name, index_type)
+    {field_name, type, opts}
+  end
+
+  defp parse_field_spec(name, {type, single_opt}, index_type)
+       when is_atom(type) and is_atom(single_opt) do
+    field_name = field_path(name, index_type)
+    {field_name, type, [{single_opt, true}]}
+  end
+
+  defp field_path(name, :json), do: "$.#{name}"
+  defp field_path(name, :hash), do: to_string(name)
+
+  defp build_field_tuple(field_name, field_type, []) do
+    {field_name, field_type}
+  end
+
+  defp build_field_tuple(field_name, field_type, opts) do
+    # For JSON fields, add an AS alias using the bare field name
+    opts =
+      if String.starts_with?(field_name, "$.") and not Keyword.has_key?(opts, :as) do
+        bare = String.trim_leading(field_name, "$.")
+        Keyword.put(opts, :as, bare)
+      else
+        opts
+      end
+
+    {field_name, field_type, opts}
+  end
+
+  # -------------------------------------------------------------------
+  # Search Option Translation
+  # -------------------------------------------------------------------
+
+  defp translate_search_opts(opts) do
+    Enum.flat_map(opts, fn
+      {:sort, {field, dir}} -> [sortby: {to_string(field), dir}]
+      {:limit, n} when is_integer(n) -> [limit: {0, n}]
+      {:limit, {offset, count}} -> [limit: {offset, count}]
+      {:return, fields} -> [return: Enum.map(fields, &to_string/1)]
+      {:nocontent, val} -> [nocontent: val]
+      {:dialect, val} -> [dialect: val]
+      _ -> []
+    end)
+  end
+
+  # -------------------------------------------------------------------
+  # Aggregation Helpers
+  # -------------------------------------------------------------------
+
+  defp maybe_add_groupby(opts, nil, _), do: opts
+
+  defp maybe_add_groupby(opts, field, reduce) when is_atom(field) do
+    maybe_add_groupby(opts, [field], reduce)
+  end
+
+  defp maybe_add_groupby(opts, fields, reduce) when is_list(fields) do
+    groupby = Enum.map(fields, &"@#{&1}")
+    reduces = Enum.map(reduce, &translate_reducer/1)
+    Keyword.merge(opts, groupby: groupby, reduce: reduces)
+  end
+
+  defp translate_reducer({:count, alias_name}) do
+    {"COUNT", 0, as: to_string(alias_name)}
+  end
+
+  defp translate_reducer({func, {field, alias_name}})
+       when func in [:sum, :avg, :min, :max] do
+    {func |> to_string() |> String.upcase(), 1, as: to_string(alias_name)}
+    |> then(fn {f, n, opts} -> {f, n, Keyword.put(opts, :__field, "@#{field}")} end)
+  end
+
+  defp maybe_add_agg_sort(opts, nil), do: opts
+
+  defp maybe_add_agg_sort(opts, {field, dir}) do
+    Keyword.put(opts, :sortby, [{"@#{field}", dir}])
+  end
+
+  defp maybe_add_limit(opts, nil), do: opts
+  defp maybe_add_limit(opts, n) when is_integer(n), do: Keyword.put(opts, :limit, {0, n})
+  defp maybe_add_limit(opts, {o, c}), do: Keyword.put(opts, :limit, {o, c})
+
+  defp maybe_add_dialect(opts, nil), do: opts
+  defp maybe_add_dialect(opts, v), do: Keyword.put(opts, :dialect, v)
+
+  # -------------------------------------------------------------------
+  # Result Parsing
+  # -------------------------------------------------------------------
+
+  defp parse_search_result(raw, coerce) when is_map(raw) do
+    # RESP3 format: %{"total_results" => n, "results" => [...]}
+    total = Map.get(raw, "total_results", 0)
+
+    results =
+      raw
+      |> Map.get("results", [])
+      |> Enum.map(fn result ->
+        id = Map.get(result, "id")
+
+        fields =
+          result
+          |> Map.get("extra_attributes", %{})
+          |> maybe_coerce(coerce)
+
+        Map.put(fields, :id, id)
+      end)
+
+    %Result{total: total, results: results}
+  end
+
+  defp parse_search_result(raw, coerce) when is_list(raw) do
+    # RESP2 format: [total, id, [field, val, ...], ...]
+    case raw do
+      [total | rest] ->
+        results = parse_resp2_results(rest, coerce)
+        %Result{total: total, results: results}
+
+      _ ->
+        %Result{}
+    end
+  end
+
+  defp parse_search_result(_, _), do: %Result{}
+
+  defp parse_resp2_results([], _), do: []
+
+  defp parse_resp2_results([id, fields | rest], coerce) when is_list(fields) do
+    field_map =
+      fields
+      |> Enum.chunk_every(2)
+      |> Map.new(fn [k, v] -> {k, v} end)
+      |> maybe_coerce(coerce)
+
+    [Map.put(field_map, :id, id) | parse_resp2_results(rest, coerce)]
+  end
+
+  defp parse_resp2_results(_, _), do: []
+
+  defp parse_aggregate_result(raw, coerce) when is_map(raw) do
+    total = Map.get(raw, "total_results", 0)
+
+    results =
+      raw
+      |> Map.get("results", [])
+      |> Enum.map(fn result ->
+        result
+        |> Map.get("extra_attributes", %{})
+        |> maybe_coerce(coerce)
+      end)
+
+    %Result{total: total, results: results}
+  end
+
+  defp parse_aggregate_result(raw, coerce) when is_list(raw) do
+    case raw do
+      [total | rest] ->
+        results = parse_resp2_agg_results(rest, coerce)
+        %Result{total: total, results: results}
+
+      _ ->
+        %Result{}
+    end
+  end
+
+  defp parse_aggregate_result(_, _), do: %Result{}
+
+  defp parse_resp2_agg_results([], _), do: []
+
+  defp parse_resp2_agg_results([fields | rest], coerce) when is_list(fields) do
+    field_map =
+      fields
+      |> Enum.chunk_every(2)
+      |> Map.new(fn [k, v] -> {k, v} end)
+      |> maybe_coerce(coerce)
+
+    [field_map | parse_resp2_agg_results(rest, coerce)]
+  end
+
+  defp parse_resp2_agg_results(_, _), do: []
+
+  # -------------------------------------------------------------------
+  # Coercion
+  # -------------------------------------------------------------------
+
+  defp maybe_coerce(map, false), do: map
+
+  defp maybe_coerce(map, true) do
+    Map.new(map, fn {k, v} -> {k, coerce_value(v)} end)
+  end
+
+  defp coerce_value(v) when is_binary(v) do
+    case Integer.parse(v) do
+      {n, ""} ->
+        n
+
+      _ ->
+        case Float.parse(v) do
+          {f, ""} -> f
+          _ -> v
+        end
+    end
+  end
+
+  defp coerce_value(v), do: v
+end

--- a/test/search_high_level_test.exs
+++ b/test/search_high_level_test.exs
@@ -1,0 +1,295 @@
+defmodule Redis.SearchTest do
+  use ExUnit.Case, async: false
+
+  alias Redis.Connection
+  alias Redis.Search
+
+  @moduletag :redis_stack
+
+  @stack_port String.to_integer(System.get_env("REDIS_STACK_PORT") || "6379")
+
+  setup do
+    {:ok, conn} = Connection.start_link(port: @stack_port)
+    suffix = :erlang.unique_integer([:positive])
+    idx = "idx:test:#{suffix}"
+    prefix = "doc:#{suffix}:"
+
+    on_exit(fn ->
+      case Connection.start_link(port: @stack_port) do
+        {:ok, cleanup} ->
+          Search.drop_index(cleanup, idx, dd: true)
+          Connection.stop(cleanup)
+
+        _ ->
+          :ok
+      end
+    end)
+
+    {:ok, conn: conn, idx: idx, prefix: prefix, suffix: suffix}
+  end
+
+  describe "create_index/3" do
+    test "creates a hash index with keyword fields", %{conn: conn, idx: idx, prefix: prefix} do
+      assert :ok =
+               Search.create_index(conn, idx,
+                 prefix: prefix,
+                 fields: [
+                   name: :text,
+                   age: {:numeric, sortable: true},
+                   city: :tag
+                 ]
+               )
+    end
+
+    test "creates a JSON index", %{conn: conn, idx: idx, prefix: prefix} do
+      assert :ok =
+               Search.create_index(conn, idx,
+                 on: :json,
+                 prefix: prefix,
+                 fields: [
+                   title: :text,
+                   score: {:numeric, sortable: true}
+                 ]
+               )
+    end
+
+    test "returns error for duplicate index", %{conn: conn, idx: idx, prefix: prefix} do
+      :ok = Search.create_index(conn, idx, prefix: prefix, fields: [name: :text])
+      assert {:error, _} = Search.create_index(conn, idx, prefix: prefix, fields: [name: :text])
+    end
+  end
+
+  describe "add/5 and find/4" do
+    test "adds hash documents and searches them", %{conn: conn, idx: idx, prefix: prefix} do
+      :ok =
+        Search.create_index(conn, idx,
+          prefix: prefix,
+          fields: [
+            name: :text,
+            age: {:numeric, sortable: true},
+            city: :tag
+          ]
+        )
+
+      Search.add(conn, idx, "#{prefix}1", %{name: "Alice", age: 30, city: "NYC"})
+      Search.add(conn, idx, "#{prefix}2", %{name: "Bob", age: 25, city: "LA"})
+      Search.add(conn, idx, "#{prefix}3", %{name: "Charlie", age: 35, city: "NYC"})
+
+      Process.sleep(200)
+
+      # Full-text search
+      {:ok, result} = Search.find(conn, idx, "Alice")
+      assert result.total >= 1
+      assert Enum.any?(result.results, &(&1[:id] == "#{prefix}1"))
+    end
+
+    test "find with numeric filter", %{conn: conn, idx: idx, prefix: prefix} do
+      :ok =
+        Search.create_index(conn, idx,
+          prefix: prefix,
+          fields: [name: :text, age: {:numeric, sortable: true}]
+        )
+
+      Search.add(conn, idx, "#{prefix}1", %{name: "Alice", age: 30})
+      Search.add(conn, idx, "#{prefix}2", %{name: "Bob", age: 25})
+      Search.add(conn, idx, "#{prefix}3", %{name: "Charlie", age: 35})
+
+      Process.sleep(200)
+
+      {:ok, result} = Search.find(conn, idx, "*", where: [age: {:gt, 28}])
+      assert result.total >= 2
+
+      ids = Enum.map(result.results, & &1[:id])
+      assert "#{prefix}1" in ids
+      assert "#{prefix}3" in ids
+    end
+
+    test "find with tag filter", %{conn: conn, idx: idx, prefix: prefix} do
+      :ok =
+        Search.create_index(conn, idx,
+          prefix: prefix,
+          fields: [name: :text, city: :tag]
+        )
+
+      Search.add(conn, idx, "#{prefix}1", %{name: "Alice", city: "NYC"})
+      Search.add(conn, idx, "#{prefix}2", %{name: "Bob", city: "LA"})
+
+      Process.sleep(200)
+
+      {:ok, result} = Search.find(conn, idx, "*", where: [city: {:tag, "NYC"}])
+      assert result.total >= 1
+      assert Enum.any?(result.results, &(&1[:id] == "#{prefix}1"))
+    end
+
+    test "find with tag OR filter", %{conn: conn, idx: idx, prefix: prefix} do
+      :ok =
+        Search.create_index(conn, idx,
+          prefix: prefix,
+          fields: [name: :text, city: :tag]
+        )
+
+      Search.add(conn, idx, "#{prefix}1", %{name: "Alice", city: "NYC"})
+      Search.add(conn, idx, "#{prefix}2", %{name: "Bob", city: "LA"})
+      Search.add(conn, idx, "#{prefix}3", %{name: "Charlie", city: "Chicago"})
+
+      Process.sleep(200)
+
+      {:ok, result} = Search.find(conn, idx, "*", where: [city: {:any, ["NYC", "LA"]}])
+      assert result.total >= 2
+    end
+
+    test "find with sort and limit", %{conn: conn, idx: idx, prefix: prefix} do
+      :ok =
+        Search.create_index(conn, idx,
+          prefix: prefix,
+          fields: [name: :text, age: {:numeric, sortable: true}]
+        )
+
+      for {name, age, i} <- [{"Alice", 30, 1}, {"Bob", 25, 2}, {"Charlie", 35, 3}] do
+        Search.add(conn, idx, "#{prefix}#{i}", %{name: name, age: age})
+      end
+
+      Process.sleep(200)
+
+      {:ok, result} = Search.find(conn, idx, "*", sort: {:age, :asc}, limit: 2)
+      assert length(result.results) == 2
+      ages = Enum.map(result.results, &(&1["age"] || &1[:age]))
+      assert ages == [25, 30]
+    end
+
+    test "find with return fields", %{conn: conn, idx: idx, prefix: prefix} do
+      :ok =
+        Search.create_index(conn, idx,
+          prefix: prefix,
+          fields: [name: :text, age: {:numeric, sortable: true}, city: :tag]
+        )
+
+      Search.add(conn, idx, "#{prefix}1", %{name: "Alice", age: 30, city: "NYC"})
+
+      Process.sleep(200)
+
+      {:ok, result} = Search.find(conn, idx, "*", return: [:name])
+      assert [doc] = result.results
+      assert doc["name"] == "Alice" or doc[:name] == "Alice"
+    end
+
+    test "find with range filter", %{conn: conn, idx: idx, prefix: prefix} do
+      :ok =
+        Search.create_index(conn, idx,
+          prefix: prefix,
+          fields: [name: :text, age: {:numeric, sortable: true}]
+        )
+
+      for {name, age, i} <- [
+            {"Alice", 30, 1},
+            {"Bob", 25, 2},
+            {"Charlie", 35, 3},
+            {"Dave", 20, 4}
+          ] do
+        Search.add(conn, idx, "#{prefix}#{i}", %{name: name, age: age})
+      end
+
+      Process.sleep(200)
+
+      {:ok, result} = Search.find(conn, idx, "*", where: [age: {:between, 25, 32}])
+      assert result.total >= 2
+    end
+  end
+
+  describe "add_many/4" do
+    test "bulk adds documents", %{conn: conn, idx: idx, prefix: prefix} do
+      :ok = Search.create_index(conn, idx, prefix: prefix, fields: [name: :text])
+
+      docs =
+        for i <- 1..5 do
+          {"#{prefix}#{i}", %{name: "User #{i}"}}
+        end
+
+      {:ok, _} = Search.add_many(conn, idx, docs)
+
+      Process.sleep(200)
+
+      {:ok, result} = Search.find(conn, idx, "*")
+      assert result.total >= 5
+    end
+  end
+
+  describe "aggregate/3" do
+    test "groups and counts", %{conn: conn, idx: idx, prefix: prefix} do
+      :ok =
+        Search.create_index(conn, idx,
+          prefix: prefix,
+          fields: [name: :text, city: :tag]
+        )
+
+      Search.add(conn, idx, "#{prefix}1", %{name: "Alice", city: "NYC"})
+      Search.add(conn, idx, "#{prefix}2", %{name: "Bob", city: "NYC"})
+      Search.add(conn, idx, "#{prefix}3", %{name: "Charlie", city: "LA"})
+
+      Process.sleep(200)
+
+      {:ok, result} =
+        Search.aggregate(conn, idx,
+          group_by: :city,
+          reduce: [count: "total"],
+          sort: {:total, :desc}
+        )
+
+      assert result.total >= 1
+      assert [_ | _] = result.results
+    end
+  end
+
+  describe "coercion" do
+    test "auto-coerces numeric strings when coerce: true", %{
+      conn: conn,
+      idx: idx,
+      prefix: prefix
+    } do
+      :ok =
+        Search.create_index(conn, idx,
+          prefix: prefix,
+          fields: [name: :text, age: {:numeric, sortable: true}]
+        )
+
+      Search.add(conn, idx, "#{prefix}1", %{name: "Alice", age: 30})
+
+      Process.sleep(200)
+
+      {:ok, result} = Search.find(conn, idx, "*", coerce: true)
+      doc = hd(result.results)
+      assert is_integer(doc["age"])
+    end
+
+    test "preserves strings when coerce: false", %{conn: conn, idx: idx, prefix: prefix} do
+      :ok =
+        Search.create_index(conn, idx,
+          prefix: prefix,
+          fields: [name: :text, age: {:numeric, sortable: true}]
+        )
+
+      Search.add(conn, idx, "#{prefix}1", %{name: "Alice", age: 30})
+
+      Process.sleep(200)
+
+      {:ok, result} = Search.find(conn, idx, "*", coerce: false)
+      doc = hd(result.results)
+      assert is_binary(doc["age"])
+    end
+  end
+
+  describe "drop_index/3" do
+    test "drops an index", %{conn: conn, idx: idx, prefix: prefix} do
+      :ok = Search.create_index(conn, idx, prefix: prefix, fields: [name: :text])
+      assert :ok = Search.drop_index(conn, idx)
+    end
+  end
+
+  describe "Result struct" do
+    test "has expected fields" do
+      r = %Search.Result{total: 5, results: [%{id: "x"}]}
+      assert r.total == 5
+      assert [%{id: "x"}] = r.results
+    end
+  end
+end


### PR DESCRIPTION
Closes #64

## Summary

`Redis.Search` -- a high-level, Meilisearch-inspired API over RediSearch.

## Before / After

**Before (raw command builders):**
```elixir
Redis.command(conn, Search.create("idx", :hash,
  prefix: "doc:", schema: [{"name", :text}, {"age", :numeric, sortable: true}]))

Redis.command(conn, ["HSET", "doc:1", "name", "Alice", "age", "30"])

Redis.command(conn, Search.search("idx", "@name:Alice @age:[(25 +inf]",
  sortby: {"age", :desc}, limit: {0, 10}))
```

**After (high-level API):**
```elixir
Redis.Search.create_index(conn, "idx",
  prefix: "doc:",
  fields: [name: :text, age: {:numeric, sortable: true}])

Redis.Search.add(conn, "idx", "doc:1", %{name: "Alice", age: 30})

Redis.Search.find(conn, "idx", "Alice",
  where: [age: {:gt, 25}], sort: {:age, :desc}, limit: 10)
#=> {:ok, %Redis.Search.Result{total: 1, results: [%{id: "doc:1", ...}]}}
```

## Features

- **Keyword schema**: `fields: [name: :text, age: {:numeric, sortable: true}]`
- **Map documents**: `add(conn, idx, key, %{name: "Alice", age: 30})`
- **Elixir filters**: `where: [age: {:gt, 18}, city: {:tag, "NYC"}]`
- **Parsed results**: `%Redis.Search.Result{total: n, results: [%{id: ..., ...}]}`
- **Auto-coercion**: numeric strings -> integers/floats (configurable)
- **JSON index support**: auto `$.path` and `AS` alias generation
- **Aggregation**: `group_by: :city, reduce: [count: "total"]`

## Tests

16 tests covering index creation (hash/JSON), document add/bulk add, text search, numeric filters, tag filters, tag OR, range filters, sort+limit, return fields, aggregation, coercion on/off, drop index, Result struct.

## Test plan

- [x] `REDIS_STACK=true mix test test/search_high_level_test.exs` -- 16 tests, 0 failures
- [x] `mix credo --strict` -- no issues