### PR TITLE
test: cover error paths and edge cases in mid-coverage modules

### DIFF
--- a/lib/redis/resilience/bulkhead.ex
+++ b/lib/redis/resilience/bulkhead.ex
@@ -79,7 +79,7 @@ defmodule Redis.Resilience.Bulkhead do
     queue =
       state.queue
       |> :queue.to_list()
-      |> Enum.reject(fn {f, _} -> f == from end)
+      |> Enum.reject(fn {f, _, _} -> f == from end)
       |> :queue.from_list()
 
     GenServer.reply(from, {:error, :bulkhead_full})

--- a/test/integration/cache_edge_test.exs
+++ b/test/integration/cache_edge_test.exs
@@ -1,0 +1,387 @@
+defmodule Redis.CacheEdgeTest do
+  use ExUnit.Case, async: false
+
+  alias Redis.Cache
+  alias Redis.Connection
+  alias Redis.Script
+
+  # Edge case tests for Redis.Cache and Redis.Script.
+  # Uses redis-server on port 6398 (no auth) from test_helper.exs.
+
+  setup do
+    {:ok, conn} = Connection.start_link(port: 6398)
+    Connection.command(conn, ["FLUSHDB"])
+    Connection.command(conn, ["SCRIPT", "FLUSH", "SYNC"])
+
+    on_exit(fn ->
+      {:ok, cleanup} = Connection.start_link(port: 6398)
+      Connection.command(cleanup, ["FLUSHDB"])
+      Connection.command(cleanup, ["SCRIPT", "FLUSH", "SYNC"])
+      Connection.stop(cleanup)
+    end)
+
+    {:ok, conn: conn}
+  end
+
+  # -------------------------------------------------------------------
+  # Cache edge cases
+  # -------------------------------------------------------------------
+
+  describe "MGET with mix of cached and uncached keys" do
+    test "returns correct values when some keys are cached and some are not", %{conn: _conn} do
+      {:ok, cache} = Cache.start_link(port: 6398)
+
+      Cache.command(cache, ["SET", "edge_m1", "alpha"])
+      Cache.command(cache, ["SET", "edge_m2", "beta"])
+      Cache.command(cache, ["SET", "edge_m3", "gamma"])
+
+      # Cache only the first and third keys via individual GETs
+      assert {:ok, "alpha"} = Cache.get(cache, "edge_m1")
+      assert {:ok, "gamma"} = Cache.get(cache, "edge_m3")
+
+      # MGET: edge_m1 and edge_m3 are cached hits, edge_m2 is a miss
+      assert {:ok, ["alpha", "beta", "gamma"]} =
+               Cache.mget(cache, ["edge_m1", "edge_m2", "edge_m3"])
+
+      stats = Cache.stats(cache)
+      # edge_m1 and edge_m3 were hits from the MGET call
+      assert stats.hits >= 2
+      # edge_m2 was a miss from the MGET call (plus initial misses for edge_m1 and edge_m3)
+      assert stats.misses >= 3
+
+      Cache.stop(cache)
+    end
+
+    test "handles MGET where all keys are already cached", %{conn: _conn} do
+      {:ok, cache} = Cache.start_link(port: 6398)
+
+      Cache.command(cache, ["SET", "edge_all1", "x"])
+      Cache.command(cache, ["SET", "edge_all2", "y"])
+
+      # Pre-warm the cache
+      Cache.get(cache, "edge_all1")
+      Cache.get(cache, "edge_all2")
+
+      # MGET should be 100% cache hits
+      assert {:ok, ["x", "y"]} = Cache.mget(cache, ["edge_all1", "edge_all2"])
+
+      stats = Cache.stats(cache)
+      assert stats.hits >= 2
+
+      Cache.stop(cache)
+    end
+
+    test "handles MGET with nil values for nonexistent keys", %{conn: _conn} do
+      {:ok, cache} = Cache.start_link(port: 6398)
+
+      Cache.command(cache, ["SET", "edge_exists", "here"])
+
+      # edge_missing does not exist in Redis
+      assert {:ok, ["here", nil]} = Cache.mget(cache, ["edge_exists", "edge_missing"])
+
+      # Second call should serve from cache (nil is a valid cached value)
+      assert {:ok, ["here", nil]} = Cache.mget(cache, ["edge_exists", "edge_missing"])
+
+      stats = Cache.stats(cache)
+      assert stats.hits >= 2
+
+      Cache.stop(cache)
+    end
+  end
+
+  describe "cache stats after a series of operations" do
+    test "tracks hits, misses, and stores accurately", %{conn: _conn} do
+      {:ok, cache} = Cache.start_link(port: 6398)
+
+      Cache.command(cache, ["SET", "stat_a", "1"])
+      Cache.command(cache, ["SET", "stat_b", "2"])
+      Cache.command(cache, ["SET", "stat_c", "3"])
+
+      # 3 misses, 3 stores
+      Cache.get(cache, "stat_a")
+      Cache.get(cache, "stat_b")
+      Cache.get(cache, "stat_c")
+
+      # 3 hits
+      Cache.get(cache, "stat_a")
+      Cache.get(cache, "stat_b")
+      Cache.get(cache, "stat_c")
+
+      # 1 miss (key does not exist, still stored as nil)
+      Cache.get(cache, "stat_nonexistent")
+
+      stats = Cache.stats(cache)
+
+      assert stats.misses == 4
+      assert stats.hits == 3
+      assert stats.stores == 4
+      assert stats.size == 4
+      assert_in_delta stats.hit_rate, 42.9, 0.5
+
+      Cache.stop(cache)
+    end
+  end
+
+  describe "HGETALL caching path" do
+    test "caches HGETALL results and serves from cache on second call", %{conn: _conn} do
+      {:ok, cache} = Cache.start_link(port: 6398)
+
+      Cache.command(cache, ["HSET", "edge_hash", "f1", "v1", "f2", "v2"])
+
+      # First call: miss
+      {:ok, result} = Cache.hgetall(cache, "edge_hash")
+      assert is_map(result) or is_list(result)
+
+      stats_after_miss = Cache.stats(cache)
+      assert stats_after_miss.misses >= 1
+
+      # Second call: hit from cache
+      {:ok, result2} = Cache.hgetall(cache, "edge_hash")
+      assert result2 == result
+
+      stats_after_hit = Cache.stats(cache)
+      assert stats_after_hit.hits >= 1
+
+      Cache.stop(cache)
+    end
+
+    test "HGETALL invalidation works when hash is modified", %{conn: _conn} do
+      {:ok, cache} = Cache.start_link(port: 6398)
+
+      Cache.command(cache, ["HSET", "inv_hash", "field", "original"])
+      {:ok, _} = Cache.hgetall(cache, "inv_hash")
+
+      # Verify it is cached
+      {:ok, _} = Cache.hgetall(cache, "inv_hash")
+      stats = Cache.stats(cache)
+      assert stats.hits >= 1
+
+      # Modify via a separate connection to trigger invalidation
+      {:ok, other} = Connection.start_link(port: 6398)
+      Connection.command(other, ["HSET", "inv_hash", "field", "modified"])
+      Process.sleep(200)
+
+      # Next call should be a miss and fetch the updated data
+      {:ok, result} = Cache.hgetall(cache, "inv_hash")
+      assert is_map(result) or is_list(result)
+
+      Connection.stop(other)
+      Cache.stop(cache)
+    end
+  end
+
+  describe "cache invalidation clears the right keys" do
+    test "invalidation of modified key evicts it while values remain correct", %{conn: _conn} do
+      {:ok, cache} = Cache.start_link(port: 6398)
+
+      Cache.command(cache, ["SET", "keep_a", "aaa"])
+      Cache.command(cache, ["SET", "evict_c", "ccc"])
+
+      # Cache both keys
+      Cache.get(cache, "keep_a")
+      Cache.get(cache, "evict_c")
+
+      stats_before = Cache.stats(cache)
+
+      # Modify only evict_c via another connection
+      {:ok, other} = Connection.start_link(port: 6398)
+      Connection.command(other, ["SET", "evict_c", "new_ccc"])
+      Process.sleep(200)
+
+      # evict_c should have been evicted and now returns the new value
+      assert {:ok, "new_ccc"} = Cache.get(cache, "evict_c")
+
+      stats_after = Cache.stats(cache)
+      assert stats_after.evictions > stats_before.evictions
+
+      # keep_a still returns the correct value regardless of cache state
+      assert {:ok, "aaa"} = Cache.get(cache, "keep_a")
+
+      Connection.stop(other)
+      Cache.stop(cache)
+    end
+
+    test "flush clears all keys but stats are preserved", %{conn: _conn} do
+      {:ok, cache} = Cache.start_link(port: 6398)
+
+      Cache.command(cache, ["SET", "flush_a", "1"])
+      Cache.command(cache, ["SET", "flush_b", "2"])
+      Cache.get(cache, "flush_a")
+      Cache.get(cache, "flush_b")
+
+      Cache.flush(cache)
+
+      stats = Cache.stats(cache)
+      assert stats.size == 0
+      # Stats counters should still reflect past operations
+      assert stats.misses == 2
+      assert stats.stores == 2
+
+      Cache.stop(cache)
+    end
+  end
+
+  describe "TTL expiry" do
+    test "short TTL expires and causes cache miss", %{conn: _conn} do
+      {:ok, cache} = Cache.start_link(port: 6398, ttl: 80)
+
+      Cache.command(cache, ["SET", "ttl_edge", "ephemeral"])
+
+      # Miss -> stored with TTL
+      assert {:ok, "ephemeral"} = Cache.get(cache, "ttl_edge")
+      # Hit while TTL is still valid
+      assert {:ok, "ephemeral"} = Cache.get(cache, "ttl_edge")
+
+      stats_before = Cache.stats(cache)
+      assert stats_before.hits == 1
+
+      # Wait for TTL to expire
+      Process.sleep(150)
+
+      # Should be a miss now due to TTL expiry
+      assert {:ok, "ephemeral"} = Cache.get(cache, "ttl_edge")
+
+      stats_after = Cache.stats(cache)
+      assert stats_after.misses == 2
+      assert stats_after.evictions >= 1
+
+      Cache.stop(cache)
+    end
+
+    test "TTL expiry does not affect keys without TTL", %{conn: _conn} do
+      # Start cache without a global TTL
+      {:ok, cache} = Cache.start_link(port: 6398)
+
+      Cache.command(cache, ["SET", "no_ttl_key", "persistent"])
+      Cache.get(cache, "no_ttl_key")
+
+      Process.sleep(150)
+
+      # Should still be a cache hit since no TTL was set
+      Cache.get(cache, "no_ttl_key")
+      stats = Cache.stats(cache)
+      assert stats.hits == 1
+
+      Cache.stop(cache)
+    end
+  end
+
+  # -------------------------------------------------------------------
+  # Script edge cases
+  # -------------------------------------------------------------------
+
+  describe "Script.new computes correct SHA1" do
+    test "SHA matches the expected SHA1 hex digest" do
+      source = "return 1"
+      script = Script.new(source)
+      expected = :crypto.hash(:sha, source) |> Base.encode16(case: :lower)
+      assert script.sha == expected
+    end
+
+    test "SHA is stable for known input" do
+      # Known SHA1 for "return 1" (verified externally)
+      script = Script.new("return 1")
+      assert script.sha == "e0e1f9fabfc9d4800c877a703b823ac0578ff8db"
+    end
+
+    test "empty script produces a valid SHA" do
+      script = Script.new("")
+      assert String.length(script.sha) == 40
+      assert script.sha == :crypto.hash(:sha, "") |> Base.encode16(case: :lower)
+    end
+  end
+
+  describe "eval with EVALSHA fast path" do
+    test "second call uses EVALSHA without fallback", %{conn: conn} do
+      script = Script.new("return 'fast_path'")
+
+      # First call: EVALSHA fails with NOSCRIPT, falls back to EVAL
+      assert {:ok, "fast_path"} = Script.eval(conn, script)
+
+      # Script is now cached on the server
+      assert Script.exists?(conn, script)
+
+      # Second call: EVALSHA succeeds directly
+      assert {:ok, "fast_path"} = Script.eval(conn, script)
+    end
+
+    test "pre-loaded script uses EVALSHA on first call", %{conn: conn} do
+      script = Script.new("return 'preloaded'")
+
+      # Pre-load the script
+      :ok = Script.load(conn, script)
+      assert Script.exists?(conn, script)
+
+      # First eval should succeed via EVALSHA without needing EVAL fallback
+      assert {:ok, "preloaded"} = Script.eval(conn, script)
+    end
+  end
+
+  describe "eval with keys and args" do
+    test "script receives keys and args correctly", %{conn: conn} do
+      script =
+        Script.new("""
+        redis.call('SET', KEYS[1], ARGV[1])
+        redis.call('SET', KEYS[2], ARGV[2])
+        return redis.call('GET', KEYS[1]) .. ':' .. redis.call('GET', KEYS[2])
+        """)
+
+      assert {:ok, "hello:world"} =
+               Script.eval(conn, script, keys: ["skey1", "skey2"], args: ["hello", "world"])
+
+      # Verify the side effects
+      assert {:ok, "hello"} = Connection.command(conn, ["GET", "skey1"])
+      assert {:ok, "world"} = Connection.command(conn, ["GET", "skey2"])
+    end
+
+    test "script with numeric args coerces to strings", %{conn: conn} do
+      script = Script.new("return ARGV[1] .. ARGV[2]")
+
+      assert {:ok, "42100"} = Script.eval(conn, script, keys: [], args: [42, 100])
+    end
+
+    test "script with empty keys and args works", %{conn: conn} do
+      script = Script.new("return 'no_args'")
+      assert {:ok, "no_args"} = Script.eval(conn, script, keys: [], args: [])
+    end
+  end
+
+  describe "Script with read-only variant (eval_ro)" do
+    test "eval_ro executes a read-only script", %{conn: conn} do
+      Connection.command(conn, ["SET", "ro_key", "ro_value"])
+
+      script = Script.new("return redis.call('GET', KEYS[1])")
+      assert {:ok, "ro_value"} = Script.eval_ro(conn, script, keys: ["ro_key"])
+    end
+
+    test "eval_ro second call uses EVALSHA_RO fast path", %{conn: conn} do
+      Connection.command(conn, ["SET", "ro_key2", "val2"])
+
+      script = Script.new("return redis.call('GET', KEYS[1])")
+
+      # First call: EVALSHA_RO fails with NOSCRIPT, falls back to EVAL_RO
+      assert {:ok, "val2"} = Script.eval_ro(conn, script, keys: ["ro_key2"])
+
+      # Script is now cached on the server
+      assert Script.exists?(conn, script)
+
+      # Second call: EVALSHA_RO succeeds directly
+      assert {:ok, "val2"} = Script.eval_ro(conn, script, keys: ["ro_key2"])
+    end
+
+    test "eval_ro with keys and args", %{conn: conn} do
+      Connection.command(conn, ["SET", "ro_a", "10"])
+      Connection.command(conn, ["SET", "ro_b", "20"])
+
+      script =
+        Script.new("return redis.call('GET', KEYS[1]) .. ':' .. redis.call('GET', KEYS[2])")
+
+      assert {:ok, "10:20"} = Script.eval_ro(conn, script, keys: ["ro_a", "ro_b"])
+    end
+
+    test "eval_ro returns nil for missing key", %{conn: conn} do
+      script = Script.new("return redis.call('GET', KEYS[1])")
+      assert {:ok, nil} = Script.eval_ro(conn, script, keys: ["nonexistent_ro_key"])
+    end
+  end
+end

--- a/test/integration/connection_edge_test.exs
+++ b/test/integration/connection_edge_test.exs
@@ -1,0 +1,425 @@
+defmodule Redis.Connection.EdgeTest do
+  use ExUnit.Case, async: false
+
+  alias Redis.Connection
+  alias Redis.Connection.Pool
+
+  # Uses redis-server started by test_helper.exs on port 6398 (no auth)
+  # and port 6399 (password: "testpass")
+
+  describe "connection with invalid host" do
+    test "sync connect to unreachable host fails" do
+      Process.flag(:trap_exit, true)
+
+      result =
+        Connection.start_link(
+          host: "192.0.2.1",
+          port: 6398,
+          timeout: 500,
+          sync_connect: true
+        )
+
+      assert {:error, _reason} = result
+    end
+
+    test "sync connect to invalid port fails" do
+      Process.flag(:trap_exit, true)
+
+      result =
+        Connection.start_link(
+          host: "127.0.0.1",
+          port: 1,
+          timeout: 500,
+          sync_connect: true
+        )
+
+      assert {:error, _reason} = result
+    end
+
+    test "async connect to unreachable host stays disconnected" do
+      {:ok, conn} =
+        Connection.start_link(
+          host: "192.0.2.1",
+          port: 6398,
+          timeout: 500,
+          sync_connect: false,
+          backoff_initial: 60_000
+        )
+
+      Process.sleep(100)
+
+      # Should be alive but not connected
+      assert Process.alive?(conn)
+      result = Connection.command(conn, ["PING"], timeout: 500)
+      assert {:error, %Redis.ConnectionError{reason: :not_connected}} = result
+
+      Connection.stop(conn)
+    end
+  end
+
+  describe "command on disconnected connection" do
+    test "command returns not_connected error" do
+      {:ok, conn} =
+        Connection.start_link(
+          host: "192.0.2.1",
+          port: 6398,
+          timeout: 500,
+          sync_connect: false,
+          backoff_initial: 60_000
+        )
+
+      Process.sleep(100)
+
+      result = Connection.command(conn, ["PING"], timeout: 500)
+      assert {:error, %Redis.ConnectionError{reason: :not_connected}} = result
+
+      Connection.stop(conn)
+    end
+
+    test "pipeline returns not_connected error" do
+      {:ok, conn} =
+        Connection.start_link(
+          host: "192.0.2.1",
+          port: 6398,
+          timeout: 500,
+          sync_connect: false,
+          backoff_initial: 60_000
+        )
+
+      Process.sleep(100)
+
+      result = Connection.pipeline(conn, [["PING"], ["PING"]], timeout: 500)
+      assert {:error, %Redis.ConnectionError{reason: :not_connected}} = result
+
+      Connection.stop(conn)
+    end
+
+    test "transaction returns not_connected error" do
+      {:ok, conn} =
+        Connection.start_link(
+          host: "192.0.2.1",
+          port: 6398,
+          timeout: 500,
+          sync_connect: false,
+          backoff_initial: 60_000
+        )
+
+      Process.sleep(100)
+
+      result = Connection.transaction(conn, [["SET", "k", "v"]], timeout: 500)
+      assert {:error, %Redis.ConnectionError{reason: :not_connected}} = result
+
+      Connection.stop(conn)
+    end
+
+    test "noreply_command returns not_connected error" do
+      {:ok, conn} =
+        Connection.start_link(
+          host: "192.0.2.1",
+          port: 6398,
+          timeout: 500,
+          sync_connect: false,
+          backoff_initial: 60_000
+        )
+
+      Process.sleep(100)
+
+      result = Connection.noreply_command(conn, ["SET", "k", "v"], timeout: 500)
+      assert {:error, %Redis.ConnectionError{reason: :not_connected}} = result
+
+      Connection.stop(conn)
+    end
+
+    test "noreply_pipeline returns not_connected error" do
+      {:ok, conn} =
+        Connection.start_link(
+          host: "192.0.2.1",
+          port: 6398,
+          timeout: 500,
+          sync_connect: false,
+          backoff_initial: 60_000
+        )
+
+      Process.sleep(100)
+
+      result = Connection.noreply_pipeline(conn, [["SET", "k", "v"]], timeout: 500)
+      assert {:error, %Redis.ConnectionError{reason: :not_connected}} = result
+
+      Connection.stop(conn)
+    end
+  end
+
+  describe "pipeline with empty command list" do
+    test "empty pipeline times out because no response is expected from server" do
+      {:ok, conn} = Connection.start_link(port: 6398)
+
+      # An empty pipeline sends no data to Redis but the caller is queued
+      # waiting for 0 decoded responses. Since process_buffer is only
+      # triggered by incoming data, the caller never gets a reply and
+      # the GenServer.call times out.
+      assert catch_exit(Connection.pipeline(conn, [], timeout: 500))
+
+      Connection.stop(conn)
+    end
+  end
+
+  describe "transaction with empty command list" do
+    test "empty transaction sends only MULTI/EXEC and returns empty results" do
+      {:ok, conn} = Connection.start_link(port: 6398)
+      Connection.command(conn, ["FLUSHDB"])
+
+      # Transaction wraps with MULTI + EXEC, so empty commands list sends
+      # [MULTI, EXEC]. EXEC returns empty list.
+      result = Connection.transaction(conn, [])
+      assert {:ok, []} = result
+
+      # Connection should remain usable
+      assert {:ok, "PONG"} = Connection.command(conn, ["PING"])
+
+      Connection.stop(conn)
+    end
+  end
+
+  describe "pool with pool_size: 1 under concurrent access" do
+    test "serialized access through single connection works" do
+      {:ok, pool} = Pool.start_link(pool_size: 1, port: 6398)
+
+      Pool.command(pool, ["FLUSHDB"])
+
+      info = Pool.info(pool)
+      assert info.pool_size == 1
+      assert info.active == 1
+
+      # Run 20 concurrent tasks through a single-connection pool
+      tasks =
+        for i <- 1..20 do
+          Task.async(fn ->
+            key = "pool1_#{i}"
+            {:ok, "OK"} = Pool.command(pool, ["SET", key, to_string(i)])
+            Pool.command(pool, ["GET", key])
+          end)
+        end
+
+      results = Enum.map(tasks, &Task.await(&1, 10_000))
+
+      for {result, i} <- Enum.with_index(results, 1) do
+        assert {:ok, to_string(i)} == result
+      end
+
+      Pool.stop(pool)
+    end
+
+    test "pipeline and transaction through single-connection pool" do
+      {:ok, pool} = Pool.start_link(pool_size: 1, port: 6398)
+
+      Pool.command(pool, ["FLUSHDB"])
+
+      {:ok, results} =
+        Pool.pipeline(pool, [
+          ["SET", "pa", "1"],
+          ["SET", "pb", "2"],
+          ["GET", "pa"],
+          ["GET", "pb"]
+        ])
+
+      assert results == ["OK", "OK", "1", "2"]
+
+      {:ok, tx_results} =
+        Pool.transaction(pool, [
+          ["INCR", "counter"],
+          ["INCR", "counter"]
+        ])
+
+      assert tx_results == [1, 2]
+
+      Pool.stop(pool)
+    end
+  end
+
+  describe "pool startup with bad connection options" do
+    test "pool fails to start when connections cannot be established" do
+      Process.flag(:trap_exit, true)
+
+      result =
+        Pool.start_link(
+          pool_size: 3,
+          host: "127.0.0.1",
+          port: 1,
+          timeout: 500,
+          sync_connect: true
+        )
+
+      assert {:error, _reason} = result
+    end
+
+    test "pool with invalid host fails to start" do
+      Process.flag(:trap_exit, true)
+
+      result =
+        Pool.start_link(
+          pool_size: 2,
+          host: "192.0.2.1",
+          port: 6398,
+          timeout: 500,
+          sync_connect: true
+        )
+
+      assert {:error, _reason} = result
+    end
+  end
+
+  describe "connection with wrong password on auth-required server" do
+    test "fails with auth_failed during HELLO handshake" do
+      Process.flag(:trap_exit, true)
+
+      result =
+        Connection.start_link(
+          port: 6399,
+          password: "completely_wrong_password",
+          sync_connect: true
+        )
+
+      assert {:error, {:auth_failed, _msg}} = result
+    end
+
+    test "fails with no password on auth-required server" do
+      Process.flag(:trap_exit, true)
+
+      result =
+        Connection.start_link(
+          port: 6399,
+          sync_connect: true
+        )
+
+      # Should be either auth_required or auth_failed depending on Redis version
+      assert {:error, {auth_error, _msg}} = result
+      assert auth_error in [:auth_failed, :auth_required]
+    end
+
+    test "pool fails to start with wrong password" do
+      Process.flag(:trap_exit, true)
+
+      result =
+        Pool.start_link(
+          pool_size: 2,
+          port: 6399,
+          password: "wrong_password",
+          sync_connect: true
+        )
+
+      assert {:error, {:auth_failed, _}} = result
+    end
+  end
+
+  describe "connection timeout behavior" do
+    test "command with zero timeout causes caller exit" do
+      {:ok, conn} = Connection.start_link(port: 6398)
+
+      # A 0ms timeout on GenServer.call should cause an exit
+      assert catch_exit(Connection.command(conn, ["PING"], timeout: 0))
+
+      Connection.stop(conn)
+    end
+
+    test "pipeline with zero timeout causes caller exit" do
+      {:ok, conn} = Connection.start_link(port: 6398)
+
+      assert catch_exit(Connection.pipeline(conn, [["SET", "a", "1"], ["GET", "a"]], timeout: 0))
+
+      Connection.stop(conn)
+    end
+  end
+
+  describe "exit_on_disconnection option" do
+    test "connection with exit_on_disconnection starts and works normally" do
+      {:ok, conn} =
+        Connection.start_link(
+          port: 6398,
+          exit_on_disconnection: true,
+          sync_connect: true
+        )
+
+      assert {:ok, "PONG"} = Connection.command(conn, ["PING"])
+      Connection.stop(conn)
+    end
+  end
+
+  describe "RESP2 protocol edge cases" do
+    test "error response through RESP2" do
+      {:ok, conn} = Connection.start_link(port: 6398, protocol: :resp2)
+
+      Connection.command(conn, ["SET", "strkey", "notanumber"])
+      assert {:error, %Redis.Error{}} = Connection.command(conn, ["INCR", "strkey"])
+
+      Connection.stop(conn)
+    end
+
+    test "empty transaction with RESP2" do
+      {:ok, conn} = Connection.start_link(port: 6398, protocol: :resp2)
+
+      result = Connection.transaction(conn, [])
+      assert {:ok, []} = result
+
+      assert {:ok, "PONG"} = Connection.command(conn, ["PING"])
+
+      Connection.stop(conn)
+    end
+
+    test "pipeline with mixed success and error in RESP2" do
+      {:ok, conn} = Connection.start_link(port: 6398, protocol: :resp2)
+
+      Connection.command(conn, ["SET", "str", "hello"])
+
+      {:ok, results} =
+        Connection.pipeline(conn, [
+          ["SET", "x", "1"],
+          ["INCR", "str"],
+          ["GET", "x"]
+        ])
+
+      assert [_, %Redis.Error{}, _] = results
+
+      Connection.stop(conn)
+    end
+  end
+
+  describe "connection database selection" do
+    test "selecting invalid database returns error" do
+      Process.flag(:trap_exit, true)
+
+      # Redis typically supports databases 0-15 by default
+      result =
+        Connection.start_link(
+          port: 6398,
+          database: 9999,
+          sync_connect: true
+        )
+
+      assert {:error, {:select_failed, _}} = result
+    end
+  end
+
+  describe "pool info reflects actual state" do
+    test "info reflects pool_size: 1" do
+      {:ok, pool} = Pool.start_link(pool_size: 1, port: 6398)
+
+      info = Pool.info(pool)
+      assert info.pool_size == 1
+      assert info.active == 1
+      assert info.strategy == :round_robin
+
+      Pool.stop(pool)
+    end
+
+    test "pool with random strategy reports correctly" do
+      {:ok, pool} = Pool.start_link(pool_size: 2, port: 6398, strategy: :random)
+
+      info = Pool.info(pool)
+      assert info.pool_size == 2
+      assert info.active == 2
+      assert info.strategy == :random
+
+      Pool.stop(pool)
+    end
+  end
+end

--- a/test/integration/pubsub_edge_test.exs
+++ b/test/integration/pubsub_edge_test.exs
@@ -1,0 +1,354 @@
+defmodule Redis.PubSubEdgeTest do
+  use ExUnit.Case, async: false
+
+  alias Redis.Connection
+  alias Redis.PubSub
+
+  # Uses redis-server on port 6398 (no auth) from test_helper.exs
+
+  describe "pattern subscribe receives pmessage" do
+    test "psubscribe with multiple patterns receives pmessage from each matching channel" do
+      {:ok, ps} = PubSub.start_link(port: 6398)
+      :ok = PubSub.psubscribe(ps, ["user:*", "order:*"], self())
+
+      assert_receive {:redis_pubsub, :subscribed, "user:*", _}, 1000
+      assert_receive {:redis_pubsub, :subscribed, "order:*", _}, 1000
+
+      {:ok, conn} = Connection.start_link(port: 6398)
+      Connection.command(conn, ["PUBLISH", "user:42:login", "session_abc"])
+      Connection.command(conn, ["PUBLISH", "order:99:created", "item_xyz"])
+      Connection.command(conn, ["PUBLISH", "other:channel", "ignored"])
+
+      assert_receive {:redis_pubsub, :pmessage, "user:*", "user:42:login", "session_abc"}, 1000
+      assert_receive {:redis_pubsub, :pmessage, "order:*", "order:99:created", "item_xyz"}, 1000
+      refute_receive {:redis_pubsub, :pmessage, _, "other:channel", _}, 300
+
+      PubSub.stop(ps)
+      Connection.stop(conn)
+    end
+  end
+
+  describe "subscriber process death auto-cleans subscription" do
+    test "killing a subscribed process removes its subscription and stops message delivery" do
+      {:ok, ps} = PubSub.start_link(port: 6398)
+      channel = "death:cleanup:#{:erlang.unique_integer([:positive])}"
+
+      # Also subscribe self so we can verify publish works
+      :ok = PubSub.subscribe(ps, channel, self())
+      assert_receive {:redis_pubsub, :subscribed, ^channel, _}, 1000
+
+      # Spawn a short-lived subscriber
+      victim =
+        spawn(fn ->
+          receive do
+            :die -> :ok
+          end
+        end)
+
+      :ok = PubSub.subscribe(ps, channel, victim)
+      Process.sleep(100)
+
+      # Both subscribers should be tracked
+      subs = PubSub.subscriptions(ps)
+      assert subs.channels[channel] == 2
+
+      # Kill the victim
+      send(victim, :die)
+      Process.sleep(200)
+
+      # Only self() should remain
+      subs = PubSub.subscriptions(ps)
+      assert subs.channels[channel] == 1
+
+      # Publish a message -- only self() should receive it, no crash from dead pid
+      {:ok, conn} = Connection.start_link(port: 6398)
+      Connection.command(conn, ["PUBLISH", channel, "after_death"])
+
+      assert_receive {:redis_pubsub, :message, ^channel, "after_death"}, 1000
+
+      PubSub.stop(ps)
+      Connection.stop(conn)
+    end
+  end
+
+  describe "multiple subscribers on the same channel" do
+    test "all subscribers receive every published message" do
+      {:ok, ps} = PubSub.start_link(port: 6398)
+      channel = "multi:sub:#{:erlang.unique_integer([:positive])}"
+
+      # Spawn two additional subscriber processes
+      parent = self()
+
+      sub1 =
+        spawn(fn ->
+          receive do
+            {:redis_pubsub, :message, _ch, payload} -> send(parent, {:sub1, payload})
+          end
+
+          # Keep alive long enough for cleanup
+          Process.sleep(1000)
+        end)
+
+      sub2 =
+        spawn(fn ->
+          receive do
+            {:redis_pubsub, :message, _ch, payload} -> send(parent, {:sub2, payload})
+          end
+
+          Process.sleep(1000)
+        end)
+
+      :ok = PubSub.subscribe(ps, channel, self())
+      :ok = PubSub.subscribe(ps, channel, sub1)
+      :ok = PubSub.subscribe(ps, channel, sub2)
+
+      assert_receive {:redis_pubsub, :subscribed, ^channel, _}, 1000
+
+      subs = PubSub.subscriptions(ps)
+      assert subs.channels[channel] == 3
+
+      {:ok, conn} = Connection.start_link(port: 6398)
+      Connection.command(conn, ["PUBLISH", channel, "broadcast"])
+
+      assert_receive {:redis_pubsub, :message, ^channel, "broadcast"}, 1000
+      assert_receive {:sub1, "broadcast"}, 1000
+      assert_receive {:sub2, "broadcast"}, 1000
+
+      PubSub.stop(ps)
+      Connection.stop(conn)
+    end
+  end
+
+  describe "unsubscribe from never-subscribed channel" do
+    test "unsubscribing from a channel that was never subscribed does not error" do
+      {:ok, ps} = PubSub.start_link(port: 6398)
+
+      # This should return :ok without raising
+      assert :ok = PubSub.unsubscribe(ps, "never:subscribed:channel", self())
+
+      # Also test pattern variant
+      assert :ok = PubSub.punsubscribe(ps, "never:subscribed:*", self())
+
+      # PubSub should still be fully functional after
+      :ok = PubSub.subscribe(ps, "after:noop:unsub", self())
+      assert_receive {:redis_pubsub, :subscribed, "after:noop:unsub", _}, 1000
+
+      PubSub.stop(ps)
+    end
+  end
+end
+
+defmodule Redis.ConsumerEdgeTest do
+  use ExUnit.Case, async: false
+
+  alias Redis.Connection
+  alias Redis.Consumer
+
+  # Uses redis-server on port 6398 from test_helper.exs
+
+  defmodule CollectorHandler do
+    @behaviour Redis.Consumer.Handler
+
+    @impl true
+    def handle_messages(messages, metadata) do
+      test_pid = :persistent_term.get(:edge_consumer_test_pid)
+
+      for [stream, entries] <- messages, [id | fields] <- entries do
+        send(test_pid, {:consumed, stream, id, fields, metadata})
+      end
+
+      :ok
+    end
+  end
+
+  defmodule SelectiveAckHandler do
+    @behaviour Redis.Consumer.Handler
+
+    @impl true
+    def handle_messages(messages, _metadata) do
+      test_pid = :persistent_term.get(:edge_consumer_test_pid)
+      send(test_pid, :selective_handler_called)
+
+      # Only ack messages whose first field key is "ack"
+      ids =
+        for [_stream, entries] <- messages,
+            [id | fields] <- entries,
+            hd(List.flatten(fields)) == "ack",
+            do: id
+
+      {:ok, ids}
+    end
+  end
+
+  defmodule CrashingHandler do
+    @behaviour Redis.Consumer.Handler
+
+    @impl true
+    def handle_messages(_messages, _metadata) do
+      test_pid = :persistent_term.get(:edge_consumer_test_pid)
+      send(test_pid, :crash_handler_called)
+      raise "intentional handler crash"
+    end
+  end
+
+  setup do
+    {:ok, conn} = Connection.start_link(port: 6398)
+    :persistent_term.put(:edge_consumer_test_pid, self())
+
+    stream = "edge:stream:#{:erlang.unique_integer([:positive])}"
+    group = "edge_group"
+
+    on_exit(fn ->
+      :persistent_term.erase(:edge_consumer_test_pid)
+
+      case Connection.start_link(port: 6398) do
+        {:ok, cleanup} ->
+          Connection.command(cleanup, ["DEL", stream])
+          Connection.stop(cleanup)
+
+        _ ->
+          :ok
+      end
+    end)
+
+    {:ok, conn: conn, stream: stream, group: group}
+  end
+
+  describe "XAUTOCLAIM recovery" do
+    test "second consumer claims messages left unacked by first consumer", %{
+      conn: conn,
+      stream: stream,
+      group: group
+    } do
+      # Create group and add messages
+      Connection.command(conn, ["XGROUP", "CREATE", stream, group, "0", "MKSTREAM"])
+
+      {:ok, id1} = Connection.command(conn, ["XADD", stream, "*", "data", "msg1"])
+      {:ok, id2} = Connection.command(conn, ["XADD", stream, "*", "data", "msg2"])
+
+      # Read messages as consumer "stale-worker" but do NOT ack them
+      Connection.command(conn, [
+        "XREADGROUP",
+        "GROUP",
+        group,
+        "stale-worker",
+        "COUNT",
+        "10",
+        "STREAMS",
+        stream,
+        ">"
+      ])
+
+      # Verify messages are pending under stale-worker
+      {:ok, pending} = Connection.command(conn, ["XPENDING", stream, group, "-", "+", "10"])
+      assert length(pending) == 2
+
+      # Start a second consumer with a very short claim interval and min idle
+      {:ok, claimer} =
+        Consumer.start_link(
+          conn: conn,
+          stream: stream,
+          group: group,
+          consumer: "claimer-worker",
+          handler: CollectorHandler,
+          block: 100,
+          claim_interval: 200,
+          claim_min_idle: 0
+        )
+
+      # The claimer should pick up the pending messages via XAUTOCLAIM
+      assert_receive {:consumed, ^stream, ^id1, _, %{claimed: true}}, 5000
+      assert_receive {:consumed, ^stream, ^id2, _, %{claimed: true}}, 5000
+
+      # After processing, messages should be acknowledged
+      Process.sleep(200)
+
+      {:ok, pending_after} =
+        Connection.command(conn, ["XPENDING", stream, group, "-", "+", "10"])
+
+      assert pending_after == [] or pending_after == nil
+
+      Consumer.stop(claimer)
+    end
+  end
+
+  describe "selective ack via {:ok, ids}" do
+    test "handler returning {:ok, ids} acks only those ids, rest stay pending", %{
+      conn: conn,
+      stream: stream,
+      group: group
+    } do
+      # Add two messages: one to ack, one to skip
+      Connection.command(conn, ["XADD", stream, "*", "ack", "yes"])
+      Connection.command(conn, ["XADD", stream, "*", "skip", "yes"])
+
+      {:ok, consumer} =
+        Consumer.start_link(
+          conn: conn,
+          stream: stream,
+          group: group,
+          consumer: "selective-worker",
+          handler: SelectiveAckHandler,
+          block: 100,
+          claim_interval: 600_000
+        )
+
+      assert_receive :selective_handler_called, 2000
+      Process.sleep(300)
+
+      # Check pending: the "skip" message should still be pending
+      {:ok, pending} = Connection.command(conn, ["XPENDING", stream, group, "-", "+", "10"])
+      assert length(pending) == 1
+
+      # The pending message should be the "skip" one
+      [entry] = pending
+      pending_id = hd(entry)
+
+      # Verify the pending message is the non-acked one by reading it
+      {:ok, messages} = Connection.command(conn, ["XRANGE", stream, pending_id, pending_id])
+      [[^pending_id, fields]] = messages
+      assert "skip" in fields
+
+      Consumer.stop(consumer)
+    end
+  end
+
+  describe "handler crash does not kill consumer" do
+    test "consumer stays alive after handler raises an exception", %{
+      conn: conn,
+      stream: stream,
+      group: group
+    } do
+      Connection.command(conn, ["XADD", stream, "*", "data", "will_crash"])
+
+      {:ok, consumer} =
+        Consumer.start_link(
+          conn: conn,
+          stream: stream,
+          group: group,
+          consumer: "crash-worker",
+          handler: CrashingHandler,
+          block: 100,
+          claim_interval: 600_000
+        )
+
+      # Wait for the handler to be called (it will crash)
+      assert_receive :crash_handler_called, 2000
+
+      # Give it a moment to recover
+      Process.sleep(300)
+
+      # Consumer process should still be alive
+      assert Process.alive?(consumer)
+
+      # Consumer should still be functional: verify it keeps polling
+      # by adding another message that also triggers the crash handler
+      Connection.command(conn, ["XADD", stream, "*", "data", "second_crash"])
+      assert_receive :crash_handler_called, 2000
+
+      assert Process.alive?(consumer)
+
+      Consumer.stop(consumer)
+    end
+  end
+end

--- a/test/integration/resilience_edge_test.exs
+++ b/test/integration/resilience_edge_test.exs
@@ -1,0 +1,381 @@
+defmodule Redis.ResilienceEdgeTest do
+  use ExUnit.Case, async: false
+
+  alias Redis.Connection
+  alias Redis.Resilience.{Bulkhead, CircuitBreaker, Coalesce, Retry}
+  alias RedisServerWrapper.Server
+
+  @moduletag timeout: 60_000
+
+  # -------------------------------------------------------------------
+  # Bulkhead edge cases
+  # -------------------------------------------------------------------
+
+  describe "Bulkhead: max_concurrent rejection under saturation" do
+    test "rejects requests when all slots are occupied" do
+      {:ok, srv} = Server.start_link(port: 6510)
+      Process.sleep(200)
+      {:ok, conn} = Connection.start_link(port: 6510, sync_connect: true)
+
+      {:ok, bh} = Bulkhead.start_link(conn: conn, max_concurrent: 2, max_wait: 0)
+
+      barrier = :ets.new(:barrier, [:set, :public])
+      :ets.insert(barrier, {:go, false})
+
+      # Saturate the bulkhead with 2 slow commands (BLPOP on nonexistent keys)
+      blockers =
+        for i <- 1..2 do
+          Task.async(fn ->
+            Bulkhead.command(bh, ["BLPOP", "edge_block_#{i}_#{System.unique_integer()}", "3"])
+          end)
+        end
+
+      # Let the blocking commands land
+      Process.sleep(200)
+
+      # Verify state shows 2 active
+      state = Bulkhead.state(bh)
+      assert state.active == 2
+
+      # Additional requests should be rejected immediately (max_wait: 0)
+      assert {:error, :bulkhead_full} = Bulkhead.command(bh, ["PING"])
+      assert {:error, :bulkhead_full} = Bulkhead.command(bh, ["PING"])
+
+      # Wait for blockers to finish
+      Task.await_many(blockers, 10_000)
+
+      # After slots free up, commands should succeed again
+      assert {:ok, "PONG"} = Bulkhead.command(bh, ["PING"])
+
+      Bulkhead.stop(bh)
+      Connection.stop(conn)
+      Server.stop(srv)
+    end
+
+    test "queued requests time out when max_wait expires" do
+      {:ok, srv} = Server.start_link(port: 6511)
+      Process.sleep(200)
+      {:ok, conn} = Connection.start_link(port: 6511, sync_connect: true)
+
+      {:ok, bh} = Bulkhead.start_link(conn: conn, max_concurrent: 1, max_wait: 200)
+
+      # Occupy the single slot with a slow command
+      blocker =
+        Task.async(fn ->
+          Bulkhead.command(bh, ["BLPOP", "edge_wait_#{System.unique_integer()}", "3"])
+        end)
+
+      Process.sleep(100)
+
+      # This request should be queued and then time out after max_wait (200ms)
+      start = System.monotonic_time(:millisecond)
+      result = Bulkhead.command(bh, ["PING"])
+      elapsed = System.monotonic_time(:millisecond) - start
+
+      assert result == {:error, :bulkhead_full}
+      # Should have waited roughly max_wait duration (allow some tolerance)
+      assert elapsed >= 150
+      assert elapsed < 1000
+
+      Task.await(blocker, 10_000)
+      Bulkhead.stop(bh)
+      Connection.stop(conn)
+      Server.stop(srv)
+    end
+  end
+
+  # -------------------------------------------------------------------
+  # CircuitBreaker edge cases
+  # -------------------------------------------------------------------
+
+  describe "CircuitBreaker: success_threshold > 1 in half-open state" do
+    test "requires multiple successes to close from half-open" do
+      {:ok, srv} = Server.start_link(port: 6512)
+      Process.sleep(200)
+      {:ok, conn} = Connection.start_link(port: 6512, sync_connect: true)
+
+      {:ok, cb} =
+        CircuitBreaker.start_link(
+          conn: conn,
+          failure_threshold: 2,
+          reset_timeout: 500,
+          success_threshold: 3
+        )
+
+      # Confirm closed
+      assert %{state: :closed} = CircuitBreaker.state(cb)
+
+      # Kill server to trigger failures
+      Server.stop(srv)
+      Process.sleep(300)
+
+      # Trip the circuit open (2 failures)
+      CircuitBreaker.command(cb, ["PING"])
+      CircuitBreaker.command(cb, ["PING"])
+      assert %{state: :open} = CircuitBreaker.state(cb)
+
+      # Restart server and wait for half-open transition
+      {:ok, srv2} = Server.start_link(port: 6512)
+      Process.sleep(2000)
+
+      state_info = CircuitBreaker.state(cb)
+      assert state_info.state in [:half_open, :closed]
+
+      if state_info.state == :half_open do
+        # First success in half-open: should NOT close yet (need 3)
+        assert {:ok, "PONG"} = CircuitBreaker.command(cb, ["PING"])
+        state_after_1 = CircuitBreaker.state(cb)
+        # Could still be half_open or might have closed if success_count reached threshold
+        # With success_threshold=3, after 1 success we should still be half_open
+        assert state_after_1.state == :half_open
+        assert state_after_1.success_count == 1
+
+        # Second success: still half-open
+        assert {:ok, "PONG"} = CircuitBreaker.command(cb, ["PING"])
+        state_after_2 = CircuitBreaker.state(cb)
+        assert state_after_2.state == :half_open
+        assert state_after_2.success_count == 2
+
+        # Third success: should close the circuit
+        assert {:ok, "PONG"} = CircuitBreaker.command(cb, ["PING"])
+
+        assert %{state: :closed, success_count: 0, failure_count: 0} =
+                 CircuitBreaker.state(cb)
+      end
+
+      CircuitBreaker.stop(cb)
+      Connection.stop(conn)
+      Server.stop(srv2)
+    end
+
+    test "state/1 returns correct counts during operation" do
+      {:ok, srv} = Server.start_link(port: 6513)
+      Process.sleep(200)
+      {:ok, conn} = Connection.start_link(port: 6513, sync_connect: true)
+
+      {:ok, cb} =
+        CircuitBreaker.start_link(
+          conn: conn,
+          failure_threshold: 5,
+          reset_timeout: 500,
+          success_threshold: 2
+        )
+
+      # Initial state
+      info = CircuitBreaker.state(cb)
+      assert info.state == :closed
+      assert info.failure_count == 0
+      assert info.success_count == 0
+
+      # A success in closed state resets failure_count to 0
+      assert {:ok, "PONG"} = CircuitBreaker.command(cb, ["PING"])
+      info = CircuitBreaker.state(cb)
+      assert info.state == :closed
+      assert info.failure_count == 0
+
+      # Kill server, produce failures
+      Server.stop(srv)
+      Process.sleep(300)
+
+      CircuitBreaker.command(cb, ["PING"])
+      info = CircuitBreaker.state(cb)
+      assert info.state == :closed
+      assert info.failure_count == 1
+
+      CircuitBreaker.command(cb, ["PING"])
+      info = CircuitBreaker.state(cb)
+      assert info.state == :closed
+      assert info.failure_count == 2
+
+      CircuitBreaker.stop(cb)
+      Connection.stop(conn)
+    end
+  end
+
+  # -------------------------------------------------------------------
+  # Retry edge cases
+  # -------------------------------------------------------------------
+
+  describe "Retry: max_attempts exhaustion" do
+    test "returns last error after all attempts exhausted" do
+      {:ok, srv} = Server.start_link(port: 6514)
+      Process.sleep(200)
+      {:ok, conn} = Connection.start_link(port: 6514, sync_connect: true)
+
+      # Kill the server so all retries fail
+      Server.stop(srv)
+      Process.sleep(300)
+
+      {:ok, retried} =
+        Retry.start_link(
+          conn: conn,
+          max_attempts: 3,
+          backoff: :fixed,
+          base_delay: 50,
+          jitter: 0.0
+        )
+
+      start = System.monotonic_time(:millisecond)
+      result = Retry.command(retried, ["PING"])
+      elapsed = System.monotonic_time(:millisecond) - start
+
+      # Should have failed with a connection error
+      assert {:error, %Redis.ConnectionError{}} = result
+
+      # Should have taken at least 2 retry delays (50ms each, 2 retries after first attempt)
+      assert elapsed >= 80
+
+      Retry.stop(retried)
+      Connection.stop(conn)
+    end
+
+    test "linear backoff increases delay linearly" do
+      {:ok, srv} = Server.start_link(port: 6514)
+      Process.sleep(200)
+      {:ok, conn} = Connection.start_link(port: 6514, sync_connect: true)
+
+      Server.stop(srv)
+      Process.sleep(300)
+
+      {:ok, retried} =
+        Retry.start_link(
+          conn: conn,
+          max_attempts: 4,
+          backoff: :linear,
+          base_delay: 100,
+          jitter: 0.0
+        )
+
+      # Linear: delays are base*1, base*2, base*3 = 100, 200, 300 = 600ms total
+      start = System.monotonic_time(:millisecond)
+      _result = Retry.command(retried, ["PING"])
+      elapsed = System.monotonic_time(:millisecond) - start
+
+      # Total delay should be around 600ms (100+200+300), allow tolerance
+      assert elapsed >= 500
+      assert elapsed < 1200
+
+      Retry.stop(retried)
+      Connection.stop(conn)
+    end
+
+    test "exponential backoff increases delay exponentially" do
+      {:ok, srv} = Server.start_link(port: 6514)
+      Process.sleep(200)
+      {:ok, conn} = Connection.start_link(port: 6514, sync_connect: true)
+
+      Server.stop(srv)
+      Process.sleep(300)
+
+      {:ok, retried} =
+        Retry.start_link(
+          conn: conn,
+          max_attempts: 4,
+          backoff: :exponential,
+          base_delay: 50,
+          jitter: 0.0
+        )
+
+      # Exponential: delays are 50*2^0, 50*2^1, 50*2^2 = 50, 100, 200 = 350ms total
+      start = System.monotonic_time(:millisecond)
+      _result = Retry.command(retried, ["PING"])
+      elapsed = System.monotonic_time(:millisecond) - start
+
+      # Total delay should be around 350ms, allow tolerance
+      assert elapsed >= 280
+      assert elapsed < 800
+
+      Retry.stop(retried)
+      Connection.stop(conn)
+    end
+
+    test "non-retryable Redis app errors are not retried" do
+      {:ok, _srv} = Server.start_link(port: 6515)
+      Process.sleep(200)
+      {:ok, conn} = Connection.start_link(port: 6515, sync_connect: true)
+
+      # Set up a string key, then try an operation that produces a WRONGTYPE error
+      {:ok, "OK"} = Connection.command(conn, ["SET", "wrongtype_key", "hello"])
+
+      {:ok, retried} =
+        Retry.start_link(
+          conn: conn,
+          max_attempts: 5,
+          backoff: :fixed,
+          base_delay: 100,
+          jitter: 0.0
+        )
+
+      # LPUSH on a string key produces WRONGTYPE error, which should NOT be retried
+      start = System.monotonic_time(:millisecond)
+      result = Retry.command(retried, ["LPUSH", "wrongtype_key", "item"])
+      elapsed = System.monotonic_time(:millisecond) - start
+
+      # Should get a Redis error (not connection error)
+      assert {:error, %Redis.Error{}} = result
+
+      # Should return almost immediately (no retries), well under one retry delay
+      assert elapsed < 80
+
+      Retry.stop(retried)
+      Connection.stop(conn)
+    end
+  end
+
+  # -------------------------------------------------------------------
+  # Coalesce edge cases
+  # -------------------------------------------------------------------
+
+  describe "Coalesce: concurrent identical commands get same result" do
+    test "multiple tasks with same command receive identical results" do
+      {:ok, _srv} = Server.start_link(port: 6515)
+      Process.sleep(200)
+      {:ok, conn} = Connection.start_link(port: 6515, sync_connect: true)
+
+      {:ok, "OK"} = Connection.command(conn, ["SET", "coal_edge_key", "shared_value"])
+
+      {:ok, coal} = Coalesce.start_link(conn: conn)
+
+      # Launch many concurrent requests for the exact same command
+      tasks =
+        for _ <- 1..20 do
+          Task.async(fn ->
+            Coalesce.command(coal, ["GET", "coal_edge_key"])
+          end)
+        end
+
+      results = Task.await_many(tasks, 10_000)
+
+      # All should get the same successful result
+      assert length(results) == 20
+      assert Enum.all?(results, &(&1 == {:ok, "shared_value"}))
+
+      Coalesce.stop(coal)
+      Connection.stop(conn)
+    end
+
+    test "different commands are not coalesced" do
+      {:ok, _srv} = Server.start_link(port: 6515)
+      Process.sleep(200)
+      {:ok, conn} = Connection.start_link(port: 6515, sync_connect: true)
+
+      {:ok, "OK"} = Connection.command(conn, ["SET", "coal_a", "val_a"])
+      {:ok, "OK"} = Connection.command(conn, ["SET", "coal_b", "val_b"])
+
+      {:ok, coal} = Coalesce.start_link(conn: conn)
+
+      # Launch concurrent requests for different keys
+      task_a = Task.async(fn -> Coalesce.command(coal, ["GET", "coal_a"]) end)
+      task_b = Task.async(fn -> Coalesce.command(coal, ["GET", "coal_b"]) end)
+
+      result_a = Task.await(task_a, 5_000)
+      result_b = Task.await(task_b, 5_000)
+
+      assert result_a == {:ok, "val_a"}
+      assert result_b == {:ok, "val_b"}
+
+      Coalesce.stop(coal)
+      Connection.stop(conn)
+    end
+  end
+end


### PR DESCRIPTION
Closes #72 (part of #69)

## Summary

65 new edge case and error path tests across 4 new test files, plus a bug fix discovered during testing.

## New tests

| File | Tests | Covers |
|---|---|---|
| `connection_edge_test.exs` | 26 | Invalid host/port, disconnected commands, empty pipeline/transaction, pool under load, auth failure, timeout, RESP2 |
| `resilience_edge_test.exs` | 10 | Bulkhead saturation, circuit breaker multi-success threshold, retry exhaustion + backoff timing, coalesce dedup |
| `cache_edge_test.exs` | 22 | MGET partial hits, stats, HGETALL caching, invalidation, TTL expiry, Script SHA1, EVALSHA fast path, eval_ro |
| `pubsub_edge_test.exs` | 7 | Pattern subscribe, subscriber death cleanup, XAUTOCLAIM recovery, selective ack, handler crash |

## Bug fix

**Bulkhead `wait_timeout` handler** -- pattern matched `{f, _}` (2-tuple) against `{from, operation, timer}` (3-tuple) queue entries, causing a `FunctionClauseError` crash when a queued request timed out. Fixed to `{f, _, _}`.

## Findings

- `pipeline(conn, [])` with empty command list hangs (no data sent to Redis, no response to trigger reply). Worth a separate fix.

## Test plan

- [x] `mix test` -- 800 tests + 13 properties, 0 failures
- [x] `mix credo --strict` -- no issues