### PR TITLE
fix: unwrap RESP3 verbatim strings to plain strings

### DIFF
--- a/lib/redis/protocol/resp3.ex
+++ b/lib/redis/protocol/resp3.ex
@@ -21,7 +21,7 @@ defmodule Redis.Protocol.RESP3 do
   | `%`         | Map             | `map()`                        |
   | `~`         | Set             | `MapSet.t()`                   |
   | `>`         | Push            | `{:push, list()}`              |
-  | `=`         | Verbatim string | `{:verbatim, enc, String.t()}` |
+  | `=`         | Verbatim string | `String.t()` (encoding stripped) |
   | `(`         | Big number      | `integer()`                    |
   """
 
@@ -254,8 +254,8 @@ defmodule Redis.Protocol.RESP3 do
         rest = binary_part(data, pos + 2, byte_size(data) - pos - 2)
 
         decode_blob_body(len_str, rest, fn blob, rest2 ->
-          <<enc::binary-size(3), ":", content::binary>> = blob
-          {:ok, {:verbatim, enc, content}, rest2}
+          <<_enc::binary-size(3), ":", content::binary>> = blob
+          {:ok, content, rest2}
         end)
 
       :nomatch ->

--- a/test/unit/protocol/resp3_test.exs
+++ b/test/unit/protocol/resp3_test.exs
@@ -82,9 +82,8 @@ defmodule Redis.Protocol.RESP3Test do
                RESP3.decode("!20\r\nERR this is an error\r\n")
     end
 
-    test "verbatim string" do
-      assert {:ok, {:verbatim, "txt", "hello"}, ""} =
-               RESP3.decode("=9\r\ntxt:hello\r\n")
+    test "verbatim string is unwrapped to plain string" do
+      assert {:ok, "hello", ""} = RESP3.decode("=9\r\ntxt:hello\r\n")
     end
   end
 


### PR DESCRIPTION
## Problem

Redis 8 returns verbatim strings for commands like INFO, DEBUG, CLIENT INFO.
These were decoded as \`{:verbatim, "txt", data}\` tuples, leaking RESP3 wire
format details to callers. \`Redis.command(conn, ["INFO"])\` returned
\`{:ok, {:verbatim, "txt", "# Server\r\n..."}}\` instead of \`{:ok, "# Server\r\n..."}\`.

## Fix

Unwrap verbatim strings at the decoder level — strip the 3-byte encoding
prefix and return the content as a plain string. This is the right layer
because verbatim strings are a wire format detail, not application semantics.

## Related

- #79 — Redis version compatibility test matrix (6, 7, 8)

## Test plan

- [x] \`mix test test/unit/protocol/\` -- 50 tests + 13 properties, 0 failures
- [x] \`mix credo --strict\` -- no issues