### PR TITLE
feat: add hash field expiration + Redis 8.x hash commands

### DIFF
--- a/lib/redis/commands/hash.ex
+++ b/lib/redis/commands/hash.ex
@@ -117,4 +117,119 @@ defmodule Redis.Commands.Hash do
   def hmset(key, pairs) when is_list(pairs) do
     ["HMSET", key | Enum.flat_map(pairs, fn {f, v} -> [f, to_string(v)] end)]
   end
+
+  # -------------------------------------------------------------------
+  # Hash field expiration (Redis 7.4+)
+  # -------------------------------------------------------------------
+
+  @doc "HEXPIRE — set TTL in seconds on hash fields. Options: :nx, :xx, :gt, :lt"
+  @spec hexpire(String.t(), integer(), [String.t()], keyword()) :: [String.t()]
+  def hexpire(key, seconds, fields, opts \\ []) when is_list(fields) do
+    ["HEXPIRE", key, to_string(seconds)] ++ condition_args(opts) ++ fields_args(fields)
+  end
+
+  @doc "HPEXPIRE — set TTL in milliseconds on hash fields."
+  @spec hpexpire(String.t(), integer(), [String.t()], keyword()) :: [String.t()]
+  def hpexpire(key, ms, fields, opts \\ []) when is_list(fields) do
+    ["HPEXPIRE", key, to_string(ms)] ++ condition_args(opts) ++ fields_args(fields)
+  end
+
+  @doc "HEXPIREAT — set expiry as Unix timestamp (seconds) on hash fields."
+  @spec hexpireat(String.t(), integer(), [String.t()], keyword()) :: [String.t()]
+  def hexpireat(key, timestamp, fields, opts \\ []) when is_list(fields) do
+    ["HEXPIREAT", key, to_string(timestamp)] ++ condition_args(opts) ++ fields_args(fields)
+  end
+
+  @doc "HPEXPIREAT — set expiry as Unix timestamp (milliseconds) on hash fields."
+  @spec hpexpireat(String.t(), integer(), [String.t()], keyword()) :: [String.t()]
+  def hpexpireat(key, ms_timestamp, fields, opts \\ []) when is_list(fields) do
+    ["HPEXPIREAT", key, to_string(ms_timestamp)] ++ condition_args(opts) ++ fields_args(fields)
+  end
+
+  @doc "HTTL — get TTL in seconds for hash fields."
+  @spec httl(String.t(), [String.t()]) :: [String.t()]
+  def httl(key, fields) when is_list(fields) do
+    ["HTTL", key | fields_args(fields)]
+  end
+
+  @doc "HPTTL — get TTL in milliseconds for hash fields."
+  @spec hpttl(String.t(), [String.t()]) :: [String.t()]
+  def hpttl(key, fields) when is_list(fields) do
+    ["HPTTL", key | fields_args(fields)]
+  end
+
+  @doc "HEXPIRETIME — get expiry as Unix timestamp (seconds) for hash fields."
+  @spec hexpiretime(String.t(), [String.t()]) :: [String.t()]
+  def hexpiretime(key, fields) when is_list(fields) do
+    ["HEXPIRETIME", key | fields_args(fields)]
+  end
+
+  @doc "HPEXPIRETIME — get expiry as Unix timestamp (ms) for hash fields."
+  @spec hpexpiretime(String.t(), [String.t()]) :: [String.t()]
+  def hpexpiretime(key, fields) when is_list(fields) do
+    ["HPEXPIRETIME", key | fields_args(fields)]
+  end
+
+  @doc "HPERSIST — remove TTL from hash fields."
+  @spec hpersist(String.t(), [String.t()]) :: [String.t()]
+  def hpersist(key, fields) when is_list(fields) do
+    ["HPERSIST", key | fields_args(fields)]
+  end
+
+  # -------------------------------------------------------------------
+  # Redis 8.0+ hash commands
+  # -------------------------------------------------------------------
+
+  @doc "HGETEX — get fields and optionally set expiration. Options: :ex, :px, :exat, :pxat, :persist"
+  @spec hgetex(String.t(), [String.t()], keyword()) :: [String.t()]
+  def hgetex(key, fields, opts \\ []) when is_list(fields) do
+    ["HGETEX", key | fields_args(fields)] ++ expiry_args(opts)
+  end
+
+  @doc "HSETEX — set fields with expiration. Options: :ex, :px, :exat, :pxat"
+  @spec hsetex(String.t(), [{String.t(), String.t()}], keyword()) :: [String.t()]
+  def hsetex(key, field_values, opts \\ []) when is_list(field_values) do
+    fv = Enum.flat_map(field_values, fn {f, v} -> [f, to_string(v)] end)
+    ["HSETEX", key | fields_args_raw(fv)] ++ expiry_args(opts)
+  end
+
+  @doc "HGETDEL — get and delete hash fields atomically."
+  @spec hgetdel(String.t(), [String.t()]) :: [String.t()]
+  def hgetdel(key, fields) when is_list(fields) do
+    ["HGETDEL", key | fields_args(fields)]
+  end
+
+  # -------------------------------------------------------------------
+  # Helpers
+  # -------------------------------------------------------------------
+
+  defp fields_args(fields) do
+    ["FIELDS", to_string(length(fields)) | fields]
+  end
+
+  defp fields_args_raw(flat_list) do
+    count = div(length(flat_list), 2)
+    ["FIELDS", to_string(count) | flat_list]
+  end
+
+  defp condition_args(opts) do
+    cond do
+      opts[:nx] -> ["NX"]
+      opts[:xx] -> ["XX"]
+      opts[:gt] -> ["GT"]
+      opts[:lt] -> ["LT"]
+      true -> []
+    end
+  end
+
+  defp expiry_args(opts) do
+    cond do
+      opts[:ex] -> ["EX", to_string(opts[:ex])]
+      opts[:px] -> ["PX", to_string(opts[:px])]
+      opts[:exat] -> ["EXAT", to_string(opts[:exat])]
+      opts[:pxat] -> ["PXAT", to_string(opts[:pxat])]
+      opts[:persist] -> ["PERSIST"]
+      true -> []
+    end
+  end
 end

--- a/test/unit/commands/hash_test.exs
+++ b/test/unit/commands/hash_test.exs
@@ -114,4 +114,81 @@ defmodule Redis.Commands.HashExpandedTest do
                ["HMSET", "h", "f1", "v1", "f2", "v2"]
     end
   end
+
+  describe "hash field expiration (7.4+)" do
+    test "HEXPIRE" do
+      assert Hash.hexpire("h", 60, ["f1", "f2"]) ==
+               ["HEXPIRE", "h", "60", "FIELDS", "2", "f1", "f2"]
+    end
+
+    test "HEXPIRE with NX" do
+      assert Hash.hexpire("h", 60, ["f1"], nx: true) ==
+               ["HEXPIRE", "h", "60", "NX", "FIELDS", "1", "f1"]
+    end
+
+    test "HEXPIRE with GT" do
+      assert Hash.hexpire("h", 60, ["f1"], gt: true) ==
+               ["HEXPIRE", "h", "60", "GT", "FIELDS", "1", "f1"]
+    end
+
+    test "HPEXPIRE" do
+      assert Hash.hpexpire("h", 5_000, ["f1"]) ==
+               ["HPEXPIRE", "h", "5000", "FIELDS", "1", "f1"]
+    end
+
+    test "HEXPIREAT" do
+      assert Hash.hexpireat("h", 1_700_000_000, ["f1"]) ==
+               ["HEXPIREAT", "h", "1700000000", "FIELDS", "1", "f1"]
+    end
+
+    test "HPEXPIREAT" do
+      assert Hash.hpexpireat("h", 1_700_000_000_000, ["f1"]) ==
+               ["HPEXPIREAT", "h", "1700000000000", "FIELDS", "1", "f1"]
+    end
+
+    test "HTTL" do
+      assert Hash.httl("h", ["f1", "f2"]) == ["HTTL", "h", "FIELDS", "2", "f1", "f2"]
+    end
+
+    test "HPTTL" do
+      assert Hash.hpttl("h", ["f1"]) == ["HPTTL", "h", "FIELDS", "1", "f1"]
+    end
+
+    test "HEXPIRETIME" do
+      assert Hash.hexpiretime("h", ["f1"]) == ["HEXPIRETIME", "h", "FIELDS", "1", "f1"]
+    end
+
+    test "HPEXPIRETIME" do
+      assert Hash.hpexpiretime("h", ["f1"]) == ["HPEXPIRETIME", "h", "FIELDS", "1", "f1"]
+    end
+
+    test "HPERSIST" do
+      assert Hash.hpersist("h", ["f1", "f2"]) == ["HPERSIST", "h", "FIELDS", "2", "f1", "f2"]
+    end
+  end
+
+  describe "Redis 8.0+ hash commands" do
+    test "HGETEX" do
+      assert Hash.hgetex("h", ["f1", "f2"]) == ["HGETEX", "h", "FIELDS", "2", "f1", "f2"]
+    end
+
+    test "HGETEX with EX" do
+      assert Hash.hgetex("h", ["f1"], ex: 60) ==
+               ["HGETEX", "h", "FIELDS", "1", "f1", "EX", "60"]
+    end
+
+    test "HGETEX with PERSIST" do
+      assert Hash.hgetex("h", ["f1"], persist: true) ==
+               ["HGETEX", "h", "FIELDS", "1", "f1", "PERSIST"]
+    end
+
+    test "HSETEX" do
+      assert Hash.hsetex("h", [{"f1", "v1"}, {"f2", "v2"}], ex: 60) ==
+               ["HSETEX", "h", "FIELDS", "2", "f1", "v1", "f2", "v2", "EX", "60"]
+    end
+
+    test "HGETDEL" do
+      assert Hash.hgetdel("h", ["f1", "f2"]) == ["HGETDEL", "h", "FIELDS", "2", "f1", "f2"]
+    end
+  end
 end


### PR DESCRIPTION
Closes #83. Adds 12 new hash commands (9 field expiration for 7.4+, 3 for 8.0+) with 16 unit tests.