### PR TITLE
fix: treat empty string env vars as unset in test_helper

### DIFF
--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,8 +1,16 @@
+env_enabled? = fn var ->
+  case System.get_env(var) do
+    nil -> false
+    "" -> false
+    _ -> true
+  end
+end
+
 exclude =
-  if(System.get_env("REDIS_STACK"), do: [], else: [:redis_stack]) ++
-    if(System.get_env("REDIS_SENTINEL"), do: [], else: [:sentinel]) ++
-    if(System.get_env("REDIS_CLUSTER_FAILOVER"), do: [], else: [:cluster_failover]) ++
-    if(System.get_env("REDIS_COMPAT"), do: [], else: [:compat])
+  if(env_enabled?.("REDIS_STACK"), do: [], else: [:redis_stack]) ++
+    if(env_enabled?.("REDIS_SENTINEL"), do: [], else: [:sentinel]) ++
+    if(env_enabled?.("REDIS_CLUSTER_FAILOVER"), do: [], else: [:cluster_failover]) ++
+    if(env_enabled?.("REDIS_COMPAT"), do: [], else: [:compat])
 
 ExUnit.start(exclude: exclude)
 
@@ -10,7 +18,7 @@ ExUnit.start(exclude: exclude)
 Mox.defmock(Redis.MockConnection, for: Redis.Connection.Behaviour)
 
 # Start redis-servers for integration tests (skip if UNIT_ONLY is set)
-unless System.get_env("UNIT_ONLY") do
+unless env_enabled?.("UNIT_ONLY") do
   {:ok, _} = RedisServerWrapper.Server.start_link(port: 6399, password: "testpass")
   {:ok, _} = RedisServerWrapper.Server.start_link(port: 6398)
 end


### PR DESCRIPTION
GitHub Actions sets env vars to empty string "" when the expression evaluates to falsy. Elixir treats "" as truthy, so `if(System.get_env("REDIS_STACK"), ...)` was including stack tests on Redis 7/8 containers that dont have FT.* commands. Fix: check for both nil and "" as disabled.