### PR TITLE
feat: add max size, eviction policy, and background sweep to cache

### DIFF
--- a/lib/redis/cache/cache.ex
+++ b/lib/redis/cache/cache.ex
@@ -39,6 +39,9 @@ defmodule Redis.Cache do
     * All `Redis.Connection` options (host, port, password, etc.)
     * `:ttl` - local TTL in ms for cached entries (default: nil, rely on server invalidation)
     * `:optin` - if true, only cache commands prefixed with CACHING YES (default: false)
+    * `:max_entries` - maximum number of cached entries (default: 10,000, 0 for unlimited)
+    * `:eviction_policy` - `:lru` or `:fifo` (default: `:lru`)
+    * `:sweep_interval` - ms between expired-entry sweeps (default: 60,000, nil to disable)
     * `:name` - GenServer name
   """
 
@@ -49,10 +52,13 @@ defmodule Redis.Cache do
 
   require Logger
 
+  @default_sweep_interval 60_000
+
   defstruct [
     :conn,
     :store,
     :ttl,
+    :sweep_interval,
     optin: false
   ]
 
@@ -105,6 +111,9 @@ defmodule Redis.Cache do
 
     {ttl, opts} = Keyword.pop(opts, :ttl)
     {optin, opts} = Keyword.pop(opts, :optin, false)
+    {max_entries, opts} = Keyword.pop(opts, :max_entries, 10_000)
+    {eviction_policy, opts} = Keyword.pop(opts, :eviction_policy, :lru)
+    {sweep_interval, opts} = Keyword.pop(opts, :sweep_interval, @default_sweep_interval)
 
     # Tell the connection to forward push messages to us
     conn_opts = Keyword.put(opts, :push_receiver, self())
@@ -117,14 +126,21 @@ defmodule Redis.Cache do
 
         case Connection.command(conn, tracking_args) do
           {:ok, "OK"} ->
-            store = Store.new()
+            store =
+              Store.new(:redis_ex_cache,
+                max_entries: max_entries,
+                eviction_policy: eviction_policy
+              )
 
             state = %__MODULE__{
               conn: conn,
               store: store,
               ttl: ttl,
-              optin: optin
+              optin: optin,
+              sweep_interval: sweep_interval
             }
+
+            schedule_sweep(sweep_interval)
 
             {:ok, state}
 
@@ -215,6 +231,12 @@ defmodule Redis.Cache do
     {:noreply, %{state | store: store}}
   end
 
+  def handle_info(:sweep, state) do
+    store = Store.sweep_expired(state.store)
+    schedule_sweep(state.sweep_interval)
+    {:noreply, %{state | store: store}}
+  end
+
   def handle_info({:EXIT, _pid, _reason}, state) do
     {:noreply, state}
   end
@@ -289,7 +311,7 @@ defmodule Redis.Cache do
   defp invalidate_hgetall_refs(store, keys) do
     Enum.reduce(keys, store, fn key, st ->
       case :ets.lookup(st.table, key) do
-        [{^key, {:hgetall_ref, cache_key}, _}] ->
+        [{^key, {:hgetall_ref, cache_key}, _, _}] ->
           Store.invalidate(st, [cache_key])
 
         _ ->
@@ -297,4 +319,11 @@ defmodule Redis.Cache do
       end
     end)
   end
+
+  defp schedule_sweep(nil), do: :ok
+
+  defp schedule_sweep(interval) when interval > 0,
+    do: Process.send_after(self(), :sweep, interval)
+
+  defp schedule_sweep(_), do: :ok
 end

--- a/lib/redis/cache/store.ex
+++ b/lib/redis/cache/store.ex
@@ -2,36 +2,68 @@ defmodule Redis.Cache.Store do
   @moduledoc """
   ETS-backed cache store for client-side caching.
 
-  Stores key → value mappings with optional TTL. Tracks hits, misses,
-  and evictions for observability.
+  Stores key -> value mappings with optional TTL, bounded size, and
+  configurable eviction policy. Tracks hits, misses, and evictions
+  for observability.
+
+  ## Options
+
+    * `:max_entries` - maximum number of entries (default: `10_000`, `0` for unlimited)
+    * `:eviction_policy` - `:lru` or `:fifo` (default: `:lru`)
   """
 
-  defstruct [:table, hits: 0, misses: 0, evictions: 0, stores: 0]
+  defstruct [
+    :table,
+    :index_table,
+    max_entries: 10_000,
+    eviction_policy: :lru,
+    hits: 0,
+    misses: 0,
+    evictions: 0,
+    stores: 0
+  ]
+
+  @type eviction_policy :: :lru | :fifo
 
   @type t :: %__MODULE__{
           table: :ets.tid(),
+          index_table: :ets.tid(),
+          max_entries: non_neg_integer(),
+          eviction_policy: eviction_policy(),
           hits: non_neg_integer(),
           misses: non_neg_integer(),
           evictions: non_neg_integer(),
           stores: non_neg_integer()
         }
 
-  @doc "Creates a new cache store backed by an ETS table."
-  @spec new(atom()) :: t()
-  def new(name \\ :redis_ex_cache) do
+  @doc "Creates a new cache store backed by ETS tables."
+  @spec new(atom(), keyword()) :: t()
+  def new(name \\ :redis_ex_cache, opts \\ []) do
+    max_entries = Keyword.get(opts, :max_entries, 10_000)
+    eviction_policy = Keyword.get(opts, :eviction_policy, :lru)
+
     table = :ets.new(name, [:set, :public, read_concurrency: true])
-    %__MODULE__{table: table}
+    index_name = :"#{name}_index"
+    index_table = :ets.new(index_name, [:ordered_set, :public])
+
+    %__MODULE__{
+      table: table,
+      index_table: index_table,
+      max_entries: max_entries,
+      eviction_policy: eviction_policy
+    }
   end
 
   @doc "Gets a value from the cache. Returns `{:hit, value, store}` or `{:miss, store}`."
   @spec get(t(), term()) :: {:hit, term(), t()} | {:miss, t()}
   def get(%__MODULE__{} = store, key) do
     case :ets.lookup(store.table, key) do
-      [{^key, value, expires_at}] ->
+      [{^key, value, expires_at, timestamp}] ->
         if expired?(expires_at) do
-          :ets.delete(store.table, key)
+          delete_entry(store, key, timestamp)
           {:miss, %{store | misses: store.misses + 1, evictions: store.evictions + 1}}
         else
+          store = maybe_touch_lru(store, key, timestamp)
           {:hit, value, %{store | hits: store.hits + 1}}
         end
 
@@ -46,20 +78,27 @@ defmodule Redis.Cache.Store do
     expires_at =
       if ttl_ms do
         System.monotonic_time(:millisecond) + ttl_ms
-      else
-        nil
       end
 
-    :ets.insert(store.table, {key, value, expires_at})
+    # Remove old index entry if key already exists
+    store = remove_old_index(store, key)
+
+    # Evict if at capacity
+    store = maybe_evict(store)
+
+    timestamp = System.unique_integer([:monotonic])
+    :ets.insert(store.table, {key, value, expires_at, timestamp})
+    :ets.insert(store.index_table, {timestamp, key})
+
     %{store | stores: store.stores + 1}
   end
 
   @doc "Invalidates one or more keys. Called when Redis pushes invalidation."
   @spec invalidate(t(), [String.t()] | nil) :: t()
   def invalidate(%__MODULE__{} = store, nil) do
-    # nil means flush all (server sent invalidate with nil key list)
     count = :ets.info(store.table, :size)
     :ets.delete_all_objects(store.table)
+    :ets.delete_all_objects(store.index_table)
     %{store | evictions: store.evictions + count}
   end
 
@@ -67,8 +106,8 @@ defmodule Redis.Cache.Store do
     evicted =
       Enum.count(keys, fn key ->
         case :ets.lookup(store.table, key) do
-          [{^key, _, _}] ->
-            :ets.delete(store.table, key)
+          [{^key, _, _, timestamp}] ->
+            delete_entry(store, key, timestamp)
             true
 
           [] ->
@@ -91,24 +130,98 @@ defmodule Redis.Cache.Store do
       evictions: store.evictions,
       stores: store.stores,
       size: :ets.info(store.table, :size),
-      hit_rate: hit_rate
+      hit_rate: hit_rate,
+      max_entries: store.max_entries,
+      eviction_policy: store.eviction_policy
     }
+  end
+
+  @doc "Removes expired entries from the cache."
+  @spec sweep_expired(t()) :: t()
+  def sweep_expired(%__MODULE__{} = store) do
+    now = System.monotonic_time(:millisecond)
+
+    expired =
+      :ets.select(store.table, [
+        {{:"$1", :_, :"$2", :"$3"}, [{:"/=", :"$2", nil}, {:<, :"$2", now}], [{{:"$1", :"$3"}}]}
+      ])
+
+    Enum.each(expired, fn {key, timestamp} ->
+      delete_entry(store, key, timestamp)
+    end)
+
+    evicted = length(expired)
+    %{store | evictions: store.evictions + evicted}
   end
 
   @doc "Clears the entire cache."
   @spec flush(t()) :: t()
   def flush(%__MODULE__{} = store) do
     :ets.delete_all_objects(store.table)
+    :ets.delete_all_objects(store.index_table)
     store
   end
 
-  @doc "Destroys the cache store (deletes the ETS table)."
+  @doc "Destroys the cache store (deletes the ETS tables)."
   @spec destroy(t()) :: :ok
-  def destroy(%__MODULE__{table: table}) do
+  def destroy(%__MODULE__{table: table, index_table: index_table}) do
     :ets.delete(table)
+    :ets.delete(index_table)
     :ok
   end
 
+  # -------------------------------------------------------------------
+  # Private helpers
+  # -------------------------------------------------------------------
+
   defp expired?(nil), do: false
   defp expired?(expires_at), do: System.monotonic_time(:millisecond) > expires_at
+
+  defp delete_entry(store, key, timestamp) do
+    :ets.delete(store.table, key)
+    :ets.delete(store.index_table, timestamp)
+  end
+
+  defp remove_old_index(store, key) do
+    case :ets.lookup(store.table, key) do
+      [{^key, _, _, old_timestamp}] ->
+        :ets.delete(store.index_table, old_timestamp)
+        store
+
+      [] ->
+        store
+    end
+  end
+
+  defp maybe_touch_lru(%{eviction_policy: :lru} = store, key, old_timestamp) do
+    :ets.delete(store.index_table, old_timestamp)
+    new_timestamp = System.unique_integer([:monotonic])
+    :ets.insert(store.index_table, {new_timestamp, key})
+    :ets.update_element(store.table, key, {4, new_timestamp})
+    store
+  end
+
+  defp maybe_touch_lru(store, _key, _timestamp), do: store
+
+  defp maybe_evict(%{max_entries: 0} = store), do: store
+
+  defp maybe_evict(%{max_entries: max} = store) do
+    if :ets.info(store.table, :size) >= max do
+      evict_one(store)
+    else
+      store
+    end
+  end
+
+  defp evict_one(store) do
+    case :ets.first(store.index_table) do
+      :"$end_of_table" ->
+        store
+
+      timestamp ->
+        [{^timestamp, key}] = :ets.lookup(store.index_table, timestamp)
+        delete_entry(store, key, timestamp)
+        %{store | evictions: store.evictions + 1}
+    end
+  end
 end

--- a/test/unit/cache/store_test.exs
+++ b/test/unit/cache/store_test.exs
@@ -1,0 +1,152 @@
+defmodule Redis.Cache.StoreTest do
+  use ExUnit.Case, async: true
+
+  alias Redis.Cache.Store
+
+  describe "max_entries with LRU eviction" do
+    test "evicts least recently used entry when at capacity" do
+      store = Store.new(:lru_evict_1, max_entries: 3, eviction_policy: :lru)
+
+      store = Store.put(store, "a", "1")
+      store = Store.put(store, "b", "2")
+      store = Store.put(store, "c", "3")
+
+      # Access "a" to make it recently used
+      {:hit, "1", store} = Store.get(store, "a")
+
+      # Insert "d" — should evict "b" (least recently used)
+      store = Store.put(store, "d", "4")
+
+      assert {:miss, _} = Store.get(store, "b")
+      assert {:hit, "1", _} = Store.get(store, "a")
+      assert {:hit, "3", _} = Store.get(store, "c")
+      assert {:hit, "4", _} = Store.get(store, "d")
+
+      stats = Store.stats(store)
+      assert stats.size == 3
+      assert stats.evictions >= 1
+
+      Store.destroy(store)
+    end
+
+    test "evicts oldest entry when no reads have occurred" do
+      store = Store.new(:lru_evict_2, max_entries: 2, eviction_policy: :lru)
+
+      store = Store.put(store, "first", "1")
+      store = Store.put(store, "second", "2")
+      store = Store.put(store, "third", "3")
+
+      assert {:miss, _} = Store.get(store, "first")
+      assert {:hit, "2", _} = Store.get(store, "second")
+      assert {:hit, "3", _} = Store.get(store, "third")
+
+      Store.destroy(store)
+    end
+  end
+
+  describe "max_entries with FIFO eviction" do
+    test "evicts first inserted entry regardless of access" do
+      store = Store.new(:fifo_evict_1, max_entries: 3, eviction_policy: :fifo)
+
+      store = Store.put(store, "a", "1")
+      store = Store.put(store, "b", "2")
+      store = Store.put(store, "c", "3")
+
+      # Access "a" — should NOT affect eviction order under FIFO
+      {:hit, "1", store} = Store.get(store, "a")
+
+      # Insert "d" — should evict "a" (first in)
+      store = Store.put(store, "d", "4")
+
+      assert {:miss, _} = Store.get(store, "a")
+      assert {:hit, "2", _} = Store.get(store, "b")
+      assert {:hit, "3", _} = Store.get(store, "c")
+      assert {:hit, "4", _} = Store.get(store, "d")
+
+      Store.destroy(store)
+    end
+  end
+
+  describe "unlimited cache (max_entries: 0)" do
+    test "does not evict entries" do
+      store = Store.new(:unlimited_1, max_entries: 0)
+
+      store =
+        Enum.reduce(1..100, store, fn i, st ->
+          Store.put(st, "key_#{i}", "val_#{i}")
+        end)
+
+      stats = Store.stats(store)
+      assert stats.size == 100
+      assert stats.evictions == 0
+
+      Store.destroy(store)
+    end
+  end
+
+  describe "overwrite existing key" do
+    test "does not increase size" do
+      store = Store.new(:overwrite_1, max_entries: 10)
+
+      store = Store.put(store, "key", "v1")
+      store = Store.put(store, "key", "v2")
+
+      assert {:hit, "v2", _} = Store.get(store, "key")
+
+      stats = Store.stats(store)
+      assert stats.size == 1
+
+      Store.destroy(store)
+    end
+  end
+
+  describe "sweep_expired" do
+    test "removes expired entries" do
+      store = Store.new(:sweep_1, max_entries: 0)
+
+      store = Store.put(store, "short", "val", 50)
+      store = Store.put(store, "long", "val", 10_000)
+      store = Store.put(store, "forever", "val")
+
+      Process.sleep(100)
+
+      store = Store.sweep_expired(store)
+
+      assert {:miss, _} = Store.get(store, "short")
+      assert {:hit, "val", _} = Store.get(store, "long")
+      assert {:hit, "val", _} = Store.get(store, "forever")
+
+      stats = Store.stats(store)
+      assert stats.evictions == 1
+
+      Store.destroy(store)
+    end
+
+    test "no-op when nothing is expired" do
+      store = Store.new(:sweep_2, max_entries: 0)
+
+      store = Store.put(store, "a", "1", 10_000)
+      store = Store.put(store, "b", "2")
+
+      store = Store.sweep_expired(store)
+
+      stats = Store.stats(store)
+      assert stats.evictions == 0
+      assert stats.size == 2
+
+      Store.destroy(store)
+    end
+  end
+
+  describe "stats include new fields" do
+    test "reports max_entries and eviction_policy" do
+      store = Store.new(:stats_1, max_entries: 500, eviction_policy: :fifo)
+
+      stats = Store.stats(store)
+      assert stats.max_entries == 500
+      assert stats.eviction_policy == :fifo
+
+      Store.destroy(store)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Add bounded cache with configurable max size (default 10,000 entries) and eviction policy (LRU or FIFO)
- Add periodic background sweep to proactively clean expired entries
- Uses a second `ordered_set` ETS table as a time index for O(1) eviction candidate lookup

## New Options

| Option | Default | Description |
|--------|---------|-------------|
| `:max_entries` | `10_000` | Max cached entries (0 for unlimited) |
| `:eviction_policy` | `:lru` | `:lru` or `:fifo` |
| `:sweep_interval` | `60_000` | ms between expired-entry sweeps (nil to disable) |

## Prior Art

Aligns with defaults from Jedis (10k/LRU), redis-py (10k/LRU), and node-redis (LRU/FIFO).

## Test plan

- [x] 8 new unit tests for LRU eviction, FIFO eviction, unlimited mode, key overwrite, sweep, and stats
- [x] All 34 existing cache tests pass unchanged
- [x] Full suite: 933 tests, 0 failures

Closes #94