### PR TITLE
feat: add cacheable command allowlist with per-command TTL

### DIFF
--- a/lib/redis/cache/allowlist.ex
+++ b/lib/redis/cache/allowlist.ex
@@ -1,0 +1,152 @@
+defmodule Redis.Cache.Allowlist do
+  @moduledoc """
+  Default allowlist of cacheable read-only Redis commands and helpers
+  for normalizing user-provided cacheable configuration.
+
+  The allowlist contains single-key read-only commands where the first
+  argument after the command name is the Redis key. Multi-key commands
+  like MGET, SDIFF, and SINTER are excluded (MGET has its own
+  specialized handler in `Redis.Cache`).
+
+  ## Configuration Formats
+
+  The `:cacheable` option accepts three formats:
+
+    * `:default` - uses the built-in allowlist with no per-command TTL overrides
+    * A list of command entries:
+      ```
+      ["GET", "HGETALL", {"LRANGE", ttl: 5_000}]
+      ```
+    * A function for full control:
+      ```
+      fn ["GET" | _] -> true; ["LRANGE" | _] -> {:ok, 5_000}; _ -> false end
+      ```
+  """
+
+  @default_commands [
+    # String / generic
+    "BITCOUNT",
+    "BITPOS",
+    "EXISTS",
+    "GET",
+    "GETBIT",
+    "GETRANGE",
+    "STRLEN",
+    "TYPE",
+    # Hash
+    "HEXISTS",
+    "HGET",
+    "HGETALL",
+    "HKEYS",
+    "HLEN",
+    "HMGET",
+    "HSTRLEN",
+    "HVALS",
+    # List
+    "LINDEX",
+    "LLEN",
+    "LPOS",
+    "LRANGE",
+    # Set (single-key only)
+    "SCARD",
+    "SISMEMBER",
+    "SMEMBERS",
+    "SMISMEMBER",
+    # Sorted Set (single-key only)
+    "ZCARD",
+    "ZCOUNT",
+    "ZLEXCOUNT",
+    "ZMSCORE",
+    "ZRANGE",
+    "ZRANGEBYLEX",
+    "ZRANGEBYSCORE",
+    "ZRANK",
+    "ZREVRANGE",
+    "ZREVRANGEBYLEX",
+    "ZREVRANGEBYSCORE",
+    "ZREVRANK",
+    "ZSCORE",
+    # Geo
+    "GEODIST",
+    "GEOHASH",
+    "GEOPOS",
+    "GEOSEARCH",
+    # Stream (single-key only)
+    "XLEN",
+    "XPENDING",
+    "XRANGE",
+    "XREVRANGE",
+    # JSON
+    "JSON.ARRINDEX",
+    "JSON.ARRLEN",
+    "JSON.GET",
+    "JSON.OBJKEYS",
+    "JSON.OBJLEN",
+    "JSON.STRLEN",
+    "JSON.TYPE",
+    # TimeSeries
+    "TS.GET",
+    "TS.INFO",
+    "TS.RANGE",
+    "TS.REVRANGE"
+  ]
+
+  @doc "Returns the default set of cacheable command names."
+  @spec default_commands() :: [String.t()]
+  def default_commands, do: @default_commands
+
+  @doc """
+  Normalizes the `:cacheable` option into an internal representation.
+
+  Returns either:
+    * `{:map, %{command => ttl | nil}}` for list/default configs
+    * `{:function, fun}` for function configs
+  """
+  @spec normalize(term()) :: {:map, %{String.t() => non_neg_integer() | nil}} | {:function, fun()}
+  def normalize(:default) do
+    {:map, Map.new(@default_commands, &{&1, nil})}
+  end
+
+  def normalize(fun) when is_function(fun, 1) do
+    {:function, fun}
+  end
+
+  def normalize(entries) when is_list(entries) do
+    map =
+      Map.new(entries, fn
+        {cmd, opts} when is_list(opts) ->
+          {String.upcase(to_string(cmd)), Keyword.get(opts, :ttl)}
+
+        cmd ->
+          {String.upcase(to_string(cmd)), nil}
+      end)
+
+    {:map, map}
+  end
+
+  @doc """
+  Checks if a command is cacheable and returns its TTL override (if any).
+
+  Returns:
+    * `{:ok, ttl}` where ttl is `nil` (use global) or a positive integer
+    * `:nocache`
+  """
+  @spec check({:map, map()} | {:function, fun()}, [String.t()]) ::
+          {:ok, non_neg_integer() | nil} | :nocache
+  def check({:map, map}, [cmd | _]) do
+    case Map.fetch(map, String.upcase(cmd)) do
+      {:ok, ttl} -> {:ok, ttl}
+      :error -> :nocache
+    end
+  end
+
+  def check({:function, fun}, args) do
+    case fun.(args) do
+      true -> {:ok, nil}
+      {:ok, ttl} -> {:ok, ttl}
+      _ -> :nocache
+    end
+  end
+
+  def check(_, _), do: :nocache
+end

--- a/lib/redis/cache/cache.ex
+++ b/lib/redis/cache/cache.ex
@@ -30,6 +30,10 @@ defmodule Redis.Cache do
       # Next call: cache miss again
       {:ok, "newval"} = Redis.Cache.get(cache, "foo")
 
+      # Generic cached command — any allowlisted command works
+      {:ok, 3} = Redis.Cache.cached_command(cache, ["LLEN", "mylist"])
+      {:ok, ["a", "b"]} = Redis.Cache.cached_command(cache, ["LRANGE", "mylist", "0", "1"])
+
       # Stats
       Redis.Cache.stats(cache)
       #=> %{hits: 1, misses: 2, evictions: 1, ...}
@@ -42,11 +46,16 @@ defmodule Redis.Cache do
     * `:max_entries` - maximum number of cached entries (default: 10,000, 0 for unlimited)
     * `:eviction_policy` - `:lru` or `:fifo` (default: `:lru`)
     * `:sweep_interval` - ms between expired-entry sweeps (default: 60,000, nil to disable)
+    * `:cacheable` - controls which commands are cached (default: `:default`).
+      Accepts `:default` (built-in allowlist), a list of command entries
+      (e.g. `["GET", {"LRANGE", ttl: 5_000}]`), or a function
+      `([String.t()] -> boolean | {:ok, ttl})`.
     * `:name` - GenServer name
   """
 
   use GenServer
 
+  alias Redis.Cache.Allowlist
   alias Redis.Cache.Store
   alias Redis.Connection
 
@@ -59,6 +68,7 @@ defmodule Redis.Cache do
     :store,
     :ttl,
     :sweep_interval,
+    :cacheable,
     optin: false
   ]
 
@@ -84,6 +94,22 @@ defmodule Redis.Cache do
   @doc "HGETALL with caching."
   @spec hgetall(GenServer.server(), String.t()) :: {:ok, term()} | {:error, term()}
   def hgetall(cache, key), do: GenServer.call(cache, {:cached_hgetall, key})
+
+  @doc """
+  Executes a command with caching if it is in the allowlist.
+
+  For allowlisted commands, results are cached locally and served from
+  cache on subsequent calls with the same arguments. The cache key is
+  derived from the full command arguments, and invalidation is tracked
+  by the Redis key (first argument after the command name).
+
+  Non-allowlisted commands are passed through to Redis without caching.
+
+      {:ok, 3} = Redis.Cache.cached_command(cache, ["LLEN", "mylist"])
+      {:ok, ["a", "b"]} = Redis.Cache.cached_command(cache, ["LRANGE", "mylist", "0", "1"])
+  """
+  @spec cached_command(GenServer.server(), [String.t()]) :: {:ok, term()} | {:error, term()}
+  def cached_command(cache, args), do: GenServer.call(cache, {:cached_command, args})
 
   @doc "Sends a command through the underlying connection (not cached)."
   @spec command(GenServer.server(), [String.t()]) :: {:ok, term()} | {:error, term()}
@@ -114,6 +140,7 @@ defmodule Redis.Cache do
     {max_entries, opts} = Keyword.pop(opts, :max_entries, 10_000)
     {eviction_policy, opts} = Keyword.pop(opts, :eviction_policy, :lru)
     {sweep_interval, opts} = Keyword.pop(opts, :sweep_interval, @default_sweep_interval)
+    {cacheable, opts} = Keyword.pop(opts, :cacheable, :default)
 
     # Tell the connection to forward push messages to us
     conn_opts = Keyword.put(opts, :push_receiver, self())
@@ -137,7 +164,8 @@ defmodule Redis.Cache do
               store: store,
               ttl: ttl,
               optin: optin,
-              sweep_interval: sweep_interval
+              sweep_interval: sweep_interval,
+              cacheable: Allowlist.normalize(cacheable)
             }
 
             schedule_sweep(sweep_interval)
@@ -212,6 +240,22 @@ defmodule Redis.Cache do
     end
   end
 
+  def handle_call({:cached_command, [cmd | _] = args}, _from, state) do
+    case Allowlist.check(state.cacheable, args) do
+      {:ok, cmd_ttl} ->
+        handle_generic_cached(args, cmd_ttl, state)
+
+      :nocache ->
+        result = Connection.command(state.conn, args)
+
+        Logger.debug(
+          "Redis.Cache: command #{cmd} not in allowlist, passing through without caching"
+        )
+
+        {:reply, result, state}
+    end
+  end
+
   def handle_call({:command, args}, _from, state) do
     {:reply, Connection.command(state.conn, args), state}
   end
@@ -228,6 +272,7 @@ defmodule Redis.Cache do
   def handle_info({:redis_push, :invalidate, keys}, state) do
     store = Store.invalidate(state.store, keys)
     store = invalidate_hgetall_refs(store, keys)
+    store = Store.invalidate_refs(store, keys)
     {:noreply, %{state | store: store}}
   end
 
@@ -266,6 +311,26 @@ defmodule Redis.Cache do
   # -------------------------------------------------------------------
   # Helpers
   # -------------------------------------------------------------------
+
+  defp handle_generic_cached([_cmd, redis_key | _] = args, cmd_ttl, state) do
+    cache_key = List.to_tuple(args)
+    ttl = cmd_ttl || state.ttl
+
+    case Store.get(state.store, cache_key) do
+      {:hit, value, store} ->
+        {:reply, {:ok, value}, %{state | store: store}}
+
+      {:miss, store} ->
+        case Connection.command(state.conn, args) do
+          {:ok, value} ->
+            store = Store.put_with_ref(store, cache_key, redis_key, value, ttl)
+            {:reply, {:ok, value}, %{state | store: store}}
+
+          error ->
+            {:reply, error, %{state | store: store}}
+        end
+    end
+  end
 
   # In OPTIN mode, pipeline returns [caching_ok, actual_result]
   defp normalize_optin_result({:ok, [_caching, value]}, true), do: {:ok, value}

--- a/lib/redis/cache/store.ex
+++ b/lib/redis/cache/store.ex
@@ -15,6 +15,7 @@ defmodule Redis.Cache.Store do
   defstruct [
     :table,
     :index_table,
+    :refs_table,
     max_entries: 10_000,
     eviction_policy: :lru,
     hits: 0,
@@ -28,6 +29,7 @@ defmodule Redis.Cache.Store do
   @type t :: %__MODULE__{
           table: :ets.tid(),
           index_table: :ets.tid(),
+          refs_table: :ets.tid(),
           max_entries: non_neg_integer(),
           eviction_policy: eviction_policy(),
           hits: non_neg_integer(),
@@ -45,10 +47,13 @@ defmodule Redis.Cache.Store do
     table = :ets.new(name, [:set, :public, read_concurrency: true])
     index_name = :"#{name}_index"
     index_table = :ets.new(index_name, [:ordered_set, :public])
+    refs_name = :"#{name}_refs"
+    refs_table = :ets.new(refs_name, [:bag, :public])
 
     %__MODULE__{
       table: table,
       index_table: index_table,
+      refs_table: refs_table,
       max_entries: max_entries,
       eviction_policy: eviction_policy
     }
@@ -93,12 +98,44 @@ defmodule Redis.Cache.Store do
     %{store | stores: store.stores + 1}
   end
 
+  @doc """
+  Puts a value in the cache and records a ref from `redis_key` to `cache_key`.
+
+  When `redis_key` is later invalidated via `invalidate_refs/2`, all cache
+  entries that reference it are removed.
+  """
+  @spec put_with_ref(t(), term(), String.t(), term(), non_neg_integer() | nil) :: t()
+  def put_with_ref(%__MODULE__{} = store, cache_key, redis_key, value, ttl_ms \\ nil) do
+    store = put(store, cache_key, value, ttl_ms)
+    :ets.insert(store.refs_table, {redis_key, cache_key})
+    store
+  end
+
+  @doc """
+  Invalidates all cache entries that reference the given Redis key(s).
+
+  Looks up the refs table to find cache keys that depend on each Redis key,
+  invalidates them, and cleans up the ref entries.
+  """
+  @spec invalidate_refs(t(), [String.t()] | nil) :: t()
+  def invalidate_refs(%__MODULE__{} = store, nil), do: store
+
+  def invalidate_refs(%__MODULE__{} = store, keys) when is_list(keys) do
+    Enum.reduce(keys, store, fn redis_key, st ->
+      refs = :ets.lookup(st.refs_table, redis_key)
+      st = invalidate_cache_keys(st, refs)
+      :ets.delete(st.refs_table, redis_key)
+      st
+    end)
+  end
+
   @doc "Invalidates one or more keys. Called when Redis pushes invalidation."
   @spec invalidate(t(), [String.t()] | nil) :: t()
   def invalidate(%__MODULE__{} = store, nil) do
     count = :ets.info(store.table, :size)
     :ets.delete_all_objects(store.table)
     :ets.delete_all_objects(store.index_table)
+    :ets.delete_all_objects(store.refs_table)
     %{store | evictions: store.evictions + count}
   end
 
@@ -159,20 +196,35 @@ defmodule Redis.Cache.Store do
   def flush(%__MODULE__{} = store) do
     :ets.delete_all_objects(store.table)
     :ets.delete_all_objects(store.index_table)
+    :ets.delete_all_objects(store.refs_table)
     store
   end
 
   @doc "Destroys the cache store (deletes the ETS tables)."
   @spec destroy(t()) :: :ok
-  def destroy(%__MODULE__{table: table, index_table: index_table}) do
+  def destroy(%__MODULE__{table: table, index_table: index_table, refs_table: refs_table}) do
     :ets.delete(table)
     :ets.delete(index_table)
+    :ets.delete(refs_table)
     :ok
   end
 
   # -------------------------------------------------------------------
   # Private helpers
   # -------------------------------------------------------------------
+
+  defp invalidate_cache_keys(store, refs) do
+    Enum.reduce(refs, store, fn {_redis_key, cache_key}, st ->
+      case :ets.lookup(st.table, cache_key) do
+        [{^cache_key, _, _, timestamp}] ->
+          delete_entry(st, cache_key, timestamp)
+          %{st | evictions: st.evictions + 1}
+
+        [] ->
+          st
+      end
+    end)
+  end
 
   defp expired?(nil), do: false
   defp expired?(expires_at), do: System.monotonic_time(:millisecond) > expires_at

--- a/test/integration/cache_allowlist_test.exs
+++ b/test/integration/cache_allowlist_test.exs
@@ -1,0 +1,202 @@
+defmodule Redis.Cache.AllowlistIntegrationTest do
+  use ExUnit.Case, async: false
+
+  alias Redis.Cache
+  alias Redis.Connection
+
+  describe "cached_command with default allowlist" do
+    test "caches LLEN results" do
+      {:ok, cache} = Cache.start_link(port: 6398)
+
+      Cache.command(cache, ["RPUSH", "al_list", "a", "b", "c"])
+
+      # First call: miss
+      assert {:ok, 3} = Cache.cached_command(cache, ["LLEN", "al_list"])
+      stats = Cache.stats(cache)
+      assert stats.misses >= 1
+
+      # Second call: hit
+      assert {:ok, 3} = Cache.cached_command(cache, ["LLEN", "al_list"])
+      stats = Cache.stats(cache)
+      assert stats.hits >= 1
+
+      Cache.command(cache, ["DEL", "al_list"])
+      Cache.stop(cache)
+    end
+
+    test "caches LRANGE results" do
+      {:ok, cache} = Cache.start_link(port: 6398)
+
+      Cache.command(cache, ["RPUSH", "al_lrange", "a", "b", "c"])
+
+      assert {:ok, ["a", "b", "c"]} =
+               Cache.cached_command(cache, ["LRANGE", "al_lrange", "0", "-1"])
+
+      # Same args -> cache hit
+      assert {:ok, ["a", "b", "c"]} =
+               Cache.cached_command(cache, ["LRANGE", "al_lrange", "0", "-1"])
+
+      stats = Cache.stats(cache)
+      assert stats.hits >= 1
+
+      # Different args -> cache miss (different range)
+      assert {:ok, ["a"]} = Cache.cached_command(cache, ["LRANGE", "al_lrange", "0", "0"])
+      stats = Cache.stats(cache)
+      assert stats.misses >= 2
+
+      Cache.command(cache, ["DEL", "al_lrange"])
+      Cache.stop(cache)
+    end
+
+    test "caches SCARD results" do
+      {:ok, cache} = Cache.start_link(port: 6398)
+
+      Cache.command(cache, ["SADD", "al_set", "a", "b", "c"])
+
+      assert {:ok, 3} = Cache.cached_command(cache, ["SCARD", "al_set"])
+      assert {:ok, 3} = Cache.cached_command(cache, ["SCARD", "al_set"])
+
+      stats = Cache.stats(cache)
+      assert stats.hits >= 1
+
+      Cache.command(cache, ["DEL", "al_set"])
+      Cache.stop(cache)
+    end
+
+    test "invalidation clears generic cached entries" do
+      {:ok, cache} = Cache.start_link(port: 6398)
+
+      Cache.command(cache, ["RPUSH", "al_inv", "x", "y"])
+
+      # Cache it
+      assert {:ok, 2} = Cache.cached_command(cache, ["LLEN", "al_inv"])
+      assert {:ok, 2} = Cache.cached_command(cache, ["LLEN", "al_inv"])
+
+      # Modify via separate connection to trigger invalidation
+      {:ok, other} = Connection.start_link(port: 6398)
+      Connection.command(other, ["RPUSH", "al_inv", "z"])
+      Process.sleep(200)
+
+      # Should be a miss now, returning updated value
+      assert {:ok, 3} = Cache.cached_command(cache, ["LLEN", "al_inv"])
+
+      stats = Cache.stats(cache)
+      assert stats.evictions >= 1
+
+      Connection.stop(other)
+      Cache.command(cache, ["DEL", "al_inv"])
+      Cache.stop(cache)
+    end
+
+    test "non-allowlisted commands pass through without caching" do
+      {:ok, cache} = Cache.start_link(port: 6398)
+
+      Cache.command(cache, ["SET", "al_passthrough", "val"])
+
+      # SET is not in the allowlist — should pass through
+      assert {:ok, "OK"} = Cache.cached_command(cache, ["SET", "al_passthrough", "newval"])
+
+      stats = Cache.stats(cache)
+      assert stats.stores == 0
+      assert stats.hits == 0
+
+      Cache.command(cache, ["DEL", "al_passthrough"])
+      Cache.stop(cache)
+    end
+  end
+
+  describe "per-command TTL override" do
+    test "command-specific TTL expires independently of global TTL" do
+      {:ok, cache} = Cache.start_link(port: 6398, ttl: 10_000, cacheable: [{"LLEN", ttl: 80}])
+
+      Cache.command(cache, ["RPUSH", "al_ttl", "a"])
+
+      # Cache with command-specific 80ms TTL
+      assert {:ok, 1} = Cache.cached_command(cache, ["LLEN", "al_ttl"])
+      assert {:ok, 1} = Cache.cached_command(cache, ["LLEN", "al_ttl"])
+
+      stats = Cache.stats(cache)
+      assert stats.hits >= 1
+
+      # Wait for command TTL to expire
+      Process.sleep(150)
+
+      # Should be a miss now
+      assert {:ok, 1} = Cache.cached_command(cache, ["LLEN", "al_ttl"])
+      stats = Cache.stats(cache)
+      assert stats.misses >= 2
+
+      Cache.command(cache, ["DEL", "al_ttl"])
+      Cache.stop(cache)
+    end
+  end
+
+  describe "custom cacheable function" do
+    test "function controls which commands are cached" do
+      cacheable = fn
+        ["LLEN" | _] -> true
+        ["SCARD" | _] -> {:ok, 5_000}
+        _ -> false
+      end
+
+      {:ok, cache} = Cache.start_link(port: 6398, cacheable: cacheable)
+
+      Cache.command(cache, ["RPUSH", "al_fn_list", "a"])
+      Cache.command(cache, ["SET", "al_fn_str", "val"])
+
+      # LLEN is cacheable
+      assert {:ok, 1} = Cache.cached_command(cache, ["LLEN", "al_fn_list"])
+      assert {:ok, 1} = Cache.cached_command(cache, ["LLEN", "al_fn_list"])
+      stats = Cache.stats(cache)
+      assert stats.hits >= 1
+
+      # GET is not cacheable via this function
+      assert {:ok, "val"} = Cache.cached_command(cache, ["GET", "al_fn_str"])
+      assert {:ok, "val"} = Cache.cached_command(cache, ["GET", "al_fn_str"])
+      stats = Cache.stats(cache)
+      # No new cache hits for GET
+      assert stats.hits == 1
+
+      Cache.command(cache, ["DEL", "al_fn_list", "al_fn_str"])
+      Cache.stop(cache)
+    end
+  end
+
+  describe "multiple cached commands for same key" do
+    test "different commands on same key are cached independently" do
+      {:ok, cache} = Cache.start_link(port: 6398)
+
+      Cache.command(cache, ["RPUSH", "al_multi", "a", "b", "c"])
+
+      # Cache LLEN and LRANGE for the same key
+      assert {:ok, 3} = Cache.cached_command(cache, ["LLEN", "al_multi"])
+
+      assert {:ok, ["a", "b", "c"]} =
+               Cache.cached_command(cache, ["LRANGE", "al_multi", "0", "-1"])
+
+      # Both should be cache hits
+      assert {:ok, 3} = Cache.cached_command(cache, ["LLEN", "al_multi"])
+
+      assert {:ok, ["a", "b", "c"]} =
+               Cache.cached_command(cache, ["LRANGE", "al_multi", "0", "-1"])
+
+      stats = Cache.stats(cache)
+      assert stats.hits >= 2
+
+      # Invalidation should clear both
+      {:ok, other} = Connection.start_link(port: 6398)
+      Connection.command(other, ["RPUSH", "al_multi", "d"])
+      Process.sleep(200)
+
+      # Both should miss now
+      assert {:ok, 4} = Cache.cached_command(cache, ["LLEN", "al_multi"])
+
+      assert {:ok, ["a", "b", "c", "d"]} =
+               Cache.cached_command(cache, ["LRANGE", "al_multi", "0", "-1"])
+
+      Connection.stop(other)
+      Cache.command(cache, ["DEL", "al_multi"])
+      Cache.stop(cache)
+    end
+  end
+end

--- a/test/unit/cache/allowlist_test.exs
+++ b/test/unit/cache/allowlist_test.exs
@@ -1,0 +1,121 @@
+defmodule Redis.Cache.AllowlistTest do
+  use ExUnit.Case, async: true
+
+  alias Redis.Cache.Allowlist
+
+  describe "normalize/1" do
+    test ":default produces a map with all default commands" do
+      {:map, map} = Allowlist.normalize(:default)
+
+      assert map["GET"] == nil
+      assert map["HGETALL"] == nil
+      assert map["LRANGE"] == nil
+      assert map["ZCARD"] == nil
+      assert map["JSON.GET"] == nil
+      assert map["TS.RANGE"] == nil
+
+      # Not in the allowlist
+      refute Map.has_key?(map, "SET")
+      refute Map.has_key?(map, "DEL")
+      refute Map.has_key?(map, "MGET")
+    end
+
+    test "list of strings" do
+      {:map, map} = Allowlist.normalize(["GET", "LLEN"])
+
+      assert map["GET"] == nil
+      assert map["LLEN"] == nil
+      assert map_size(map) == 2
+    end
+
+    test "list with per-command TTL" do
+      {:map, map} = Allowlist.normalize(["GET", {"LRANGE", ttl: 5_000}])
+
+      assert map["GET"] == nil
+      assert map["LRANGE"] == 5_000
+    end
+
+    test "list normalizes case" do
+      {:map, map} = Allowlist.normalize(["get", {"lrange", ttl: 1_000}])
+
+      assert map["GET"] == nil
+      assert map["LRANGE"] == 1_000
+    end
+
+    test "function is stored as-is" do
+      fun = fn
+        ["GET" | _] -> true
+        _ -> false
+      end
+
+      assert {:function, ^fun} = Allowlist.normalize(fun)
+    end
+  end
+
+  describe "check/2" do
+    test "map — command in allowlist" do
+      config = Allowlist.normalize(:default)
+      assert {:ok, nil} = Allowlist.check(config, ["GET", "mykey"])
+    end
+
+    test "map — command not in allowlist" do
+      config = Allowlist.normalize(:default)
+      assert :nocache = Allowlist.check(config, ["SET", "mykey", "val"])
+    end
+
+    test "map — per-command TTL" do
+      config = Allowlist.normalize([{"LRANGE", ttl: 3_000}])
+      assert {:ok, 3_000} = Allowlist.check(config, ["LRANGE", "mylist", "0", "10"])
+    end
+
+    test "map — case insensitive command matching" do
+      config = Allowlist.normalize(:default)
+      assert {:ok, nil} = Allowlist.check(config, ["get", "mykey"])
+    end
+
+    test "function — returns true" do
+      config =
+        Allowlist.normalize(fn
+          ["GET" | _] -> true
+          _ -> false
+        end)
+
+      assert {:ok, nil} = Allowlist.check(config, ["GET", "mykey"])
+    end
+
+    test "function — returns {:ok, ttl}" do
+      config = Allowlist.normalize(fn _ -> {:ok, 5_000} end)
+      assert {:ok, 5_000} = Allowlist.check(config, ["LRANGE", "mylist", "0", "10"])
+    end
+
+    test "function — returns false" do
+      config = Allowlist.normalize(fn _ -> false end)
+      assert :nocache = Allowlist.check(config, ["GET", "mykey"])
+    end
+  end
+
+  describe "default_commands/0" do
+    test "returns a non-empty list of strings" do
+      commands = Allowlist.default_commands()
+      assert is_list(commands)
+      assert length(commands) > 50
+      assert Enum.all?(commands, &is_binary/1)
+    end
+
+    test "does not include write commands" do
+      commands = Allowlist.default_commands()
+      refute "SET" in commands
+      refute "DEL" in commands
+      refute "LPUSH" in commands
+      refute "ZADD" in commands
+    end
+
+    test "does not include multi-key commands" do
+      commands = Allowlist.default_commands()
+      refute "MGET" in commands
+      refute "SDIFF" in commands
+      refute "SINTER" in commands
+      refute "SUNION" in commands
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Add configurable allowlist of ~60 read-only commands eligible for client-side caching
- Add generic `cached_command/2` API that caches any allowlisted command automatically
- Support per-command TTL overrides (e.g., `{"LRANGE", ttl: 5_000}`)
- Support custom cacheable function for full control
- Add ref-tracking in Store for correct invalidation when multiple commands cache the same Redis key

## New Option

`:cacheable` accepts three formats:

```elixir
# Default: built-in allowlist of ~60 read-only commands
cacheable: :default

# Custom list with optional per-command TTL
cacheable: ["GET", "LLEN", {"LRANGE", ttl: 5_000}]

# Function for full control
cacheable: fn ["GET" | _] -> true; _ -> false end
```

## New Files

- `lib/redis/cache/allowlist.ex` - allowlist definition, normalization, and checking
- `test/unit/cache/allowlist_test.exs` - unit tests for allowlist logic
- `test/integration/cache_allowlist_test.exs` - integration tests with Redis

## Test plan

- [x] 11 unit tests for allowlist normalization/checking
- [x] 12 integration tests: LLEN, LRANGE, SCARD caching; invalidation; passthrough; per-command TTL; custom function; multi-command same key
- [x] All 42 existing cache tests pass unchanged
- [x] 65 total tests, 0 failures

Closes #95