### PR TITLE
feat: add pluggable cache backend via behaviour

### DIFF
--- a/lib/redis/cache/backend.ex
+++ b/lib/redis/cache/backend.ex
@@ -1,0 +1,101 @@
+defmodule Redis.Cache.Backend do
+  @moduledoc """
+  Behaviour for pluggable client-side cache backends.
+
+  The default implementation is `Redis.Cache.Store`, which uses ETS tables
+  with bounded size, LRU/FIFO eviction, and TTL support.
+
+  Implement this behaviour to use an alternative cache backend (e.g., Cachex,
+  ConCache, or a custom store).
+
+  ## Example
+
+      defmodule MyApp.CachexBackend do
+        @behaviour Redis.Cache.Backend
+
+        @impl true
+        def init(opts) do
+          name = Keyword.get(opts, :name, :my_cache)
+          {:ok, _pid} = Cachex.start_link(name)
+          {:ok, %{name: name}}
+        end
+
+        @impl true
+        def get(state, key) do
+          case Cachex.get(state.name, key) do
+            {:ok, nil} -> {:miss, state}
+            {:ok, value} -> {:hit, value, state}
+          end
+        end
+
+        # ... implement remaining callbacks
+      end
+
+  Then pass it when starting the cache:
+
+      Redis.Cache.start_link(
+        port: 6379,
+        backend: MyApp.CachexBackend,
+        backend_opts: [name: :my_redis_cache]
+      )
+  """
+
+  @type state :: term()
+
+  @doc "Initializes the backend. Returns `{:ok, state}` or `{:error, reason}`."
+  @callback init(opts :: keyword()) :: {:ok, state()} | {:error, term()}
+
+  @doc """
+  Gets a value from the cache.
+
+  Returns `{:hit, value, state}` on cache hit or `{:miss, state}` on miss.
+  """
+  @callback get(state(), key :: term()) ::
+              {:hit, value :: term(), state()} | {:miss, state()}
+
+  @doc "Puts a value in the cache with optional TTL in milliseconds."
+  @callback put(state(), key :: term(), value :: term(), ttl_ms :: non_neg_integer() | nil) ::
+              state()
+
+  @doc """
+  Puts a value and records a ref from `redis_key` to `cache_key`.
+
+  When `redis_key` is later invalidated via `invalidate_refs/2`, all cache
+  entries that reference it should be removed.
+  """
+  @callback put_with_ref(
+              state(),
+              cache_key :: term(),
+              redis_key :: String.t(),
+              value :: term(),
+              ttl_ms :: non_neg_integer() | nil
+            ) :: state()
+
+  @doc """
+  Invalidates all cache entries that reference the given Redis key(s).
+
+  Called when Redis pushes invalidation for keys that were cached via
+  `put_with_ref/5`. A `nil` keys argument is a no-op.
+  """
+  @callback invalidate_refs(state(), keys :: [String.t()] | nil) :: state()
+
+  @doc """
+  Invalidates one or more keys directly.
+
+  Called when Redis pushes invalidation. A `nil` keys argument means
+  flush all entries.
+  """
+  @callback invalidate(state(), keys :: [String.t()] | nil) :: state()
+
+  @doc "Returns cache statistics as a map."
+  @callback stats(state()) :: map()
+
+  @doc "Removes expired entries from the cache."
+  @callback sweep_expired(state()) :: state()
+
+  @doc "Clears the entire cache."
+  @callback flush(state()) :: state()
+
+  @doc "Destroys the cache backend and releases resources."
+  @callback destroy(state()) :: :ok
+end

--- a/lib/redis/cache/cache.ex
+++ b/lib/redis/cache/cache.ex
@@ -2,35 +2,35 @@ defmodule Redis.Cache do
   @moduledoc """
   Client-side caching using RESP3 server-assisted invalidation.
 
-  Wraps a `Redis.Connection` and caches read command results in an ETS table.
-  The Redis server tracks which keys this client has read and pushes invalidation
-  messages when those keys are modified by any client.
+  Wraps a `Redis.Connection` and caches read command results locally.
+  The Redis server tracks which keys this client has read and pushes
+  invalidation messages when those keys are modified by any client.
 
   ## How It Works
 
   1. On start, sends `CLIENT TRACKING ON` to enable server-assisted tracking
-  2. Read commands (GET, MGET, HGETALL, etc.) check ETS first
+  2. Read commands (GET, MGET, HGETALL, etc.) check the local cache first
   3. Cache misses go to Redis — response is cached before returning
   4. When any client modifies a cached key, Redis pushes an `invalidate` message
   5. The push arrives as `{:redis_push, :invalidate, keys}` from Connection
-  6. Cache evicts those keys from ETS
+  6. Cache evicts those keys locally
   7. Next read goes to Redis again
 
   ## Usage
 
       {:ok, cache} = Redis.Cache.start_link(port: 6379)
 
-      # First call: cache miss → hits Redis
+      # First call: cache miss -> hits Redis
       {:ok, "bar"} = Redis.Cache.get(cache, "foo")
 
-      # Second call: cache hit → served from ETS
+      # Second call: cache hit -> served locally
       {:ok, "bar"} = Redis.Cache.get(cache, "foo")
 
-      # Another client does SET foo newval → invalidation push → ETS evicted
+      # Another client does SET foo newval -> invalidation push -> evicted
       # Next call: cache miss again
       {:ok, "newval"} = Redis.Cache.get(cache, "foo")
 
-      # Generic cached command — any allowlisted command works
+      # Generic cached command -- any allowlisted command works
       {:ok, 3} = Redis.Cache.cached_command(cache, ["LLEN", "mylist"])
       {:ok, ["a", "b"]} = Redis.Cache.cached_command(cache, ["LRANGE", "mylist", "0", "1"])
 
@@ -50,6 +50,8 @@ defmodule Redis.Cache do
       Accepts `:default` (built-in allowlist), a list of command entries
       (e.g. `["GET", {"LRANGE", ttl: 5_000}]`), or a function
       `([String.t()] -> boolean | {:ok, ttl})`.
+    * `:backend` - module implementing `Redis.Cache.Backend` (default: `Redis.Cache.Store`)
+    * `:backend_opts` - additional keyword list passed to `backend.init/1`
     * `:name` - GenServer name
   """
 
@@ -66,6 +68,7 @@ defmodule Redis.Cache do
   defstruct [
     :conn,
     :store,
+    :backend,
     :ttl,
     :sweep_interval,
     :cacheable,
@@ -141,6 +144,8 @@ defmodule Redis.Cache do
     {eviction_policy, opts} = Keyword.pop(opts, :eviction_policy, :lru)
     {sweep_interval, opts} = Keyword.pop(opts, :sweep_interval, @default_sweep_interval)
     {cacheable, opts} = Keyword.pop(opts, :cacheable, :default)
+    {backend, opts} = Keyword.pop(opts, :backend, Store)
+    {backend_opts, opts} = Keyword.pop(opts, :backend_opts, [])
 
     # Tell the connection to forward push messages to us
     conn_opts = Keyword.put(opts, :push_receiver, self())
@@ -151,31 +156,20 @@ defmodule Redis.Cache do
         tracking_args = ["CLIENT", "TRACKING", "ON"]
         tracking_args = if optin, do: tracking_args ++ ["OPTIN"], else: tracking_args
 
-        case Connection.command(conn, tracking_args) do
-          {:ok, "OK"} ->
-            store =
-              Store.new(:redis_ex_cache,
-                max_entries: max_entries,
-                eviction_policy: eviction_policy
-              )
+        store_opts =
+          [max_entries: max_entries, eviction_policy: eviction_policy] ++ backend_opts
 
-            state = %__MODULE__{
-              conn: conn,
-              store: store,
-              ttl: ttl,
-              optin: optin,
-              sweep_interval: sweep_interval,
-              cacheable: Allowlist.normalize(cacheable)
-            }
+        init_opts = %{
+          conn: conn,
+          backend: backend,
+          store_opts: store_opts,
+          ttl: ttl,
+          optin: optin,
+          sweep_interval: sweep_interval,
+          cacheable: cacheable
+        }
 
-            schedule_sweep(sweep_interval)
-
-            {:ok, state}
-
-          {:error, reason} ->
-            Connection.stop(conn)
-            {:stop, {:tracking_failed, reason}}
-        end
+        init_tracking_and_store(conn, tracking_args, init_opts)
 
       {:error, reason} ->
         {:stop, reason}
@@ -184,7 +178,9 @@ defmodule Redis.Cache do
 
   @impl true
   def handle_call({:cached_get, key}, _from, state) do
-    case Store.get(state.store, key) do
+    %{backend: backend} = state
+
+    case backend.get(state.store, key) do
       {:hit, value, store} ->
         {:reply, {:ok, value}, %{state | store: store}}
 
@@ -199,7 +195,7 @@ defmodule Redis.Cache do
 
         case normalize_optin_result(result, state.optin) do
           {:ok, value} ->
-            store = Store.put(store, key, value, state.ttl)
+            store = backend.put(store, key, value, state.ttl)
             {:reply, {:ok, value}, %{state | store: store}}
 
           error ->
@@ -209,7 +205,7 @@ defmodule Redis.Cache do
   end
 
   def handle_call({:cached_mget, keys}, _from, state) do
-    {cached, missed_keys, missed_indices, store} = check_cache_for_keys(keys, state.store)
+    {cached, missed_keys, missed_indices, store} = check_cache_for_keys(keys, state)
 
     if missed_keys == [] do
       values = Enum.map(0..(length(keys) - 1), &Map.get(cached, &1))
@@ -220,18 +216,19 @@ defmodule Redis.Cache do
   end
 
   def handle_call({:cached_hgetall, key}, _from, state) do
+    %{backend: backend} = state
     cache_key = {:hgetall, key}
 
-    case Store.get(state.store, cache_key) do
+    case backend.get(state.store, cache_key) do
       {:hit, value, store} ->
         {:reply, {:ok, value}, %{state | store: store}}
 
       {:miss, store} ->
         case Connection.command(state.conn, ["HGETALL", key]) do
           {:ok, value} ->
-            store = Store.put(store, cache_key, value, state.ttl)
+            store = backend.put(store, cache_key, value, state.ttl)
             # Also track by the raw key for invalidation
-            store = Store.put(store, key, {:hgetall_ref, cache_key}, state.ttl)
+            store = backend.put(store, key, {:hgetall_ref, cache_key}, state.ttl)
             {:reply, {:ok, value}, %{state | store: store}}
 
           error ->
@@ -261,23 +258,24 @@ defmodule Redis.Cache do
   end
 
   def handle_call(:stats, _from, state) do
-    {:reply, Store.stats(state.store), state}
+    {:reply, state.backend.stats(state.store), state}
   end
 
   def handle_call(:flush, _from, state) do
-    {:reply, :ok, %{state | store: Store.flush(state.store)}}
+    {:reply, :ok, %{state | store: state.backend.flush(state.store)}}
   end
 
   @impl true
   def handle_info({:redis_push, :invalidate, keys}, state) do
-    store = Store.invalidate(state.store, keys)
-    store = invalidate_hgetall_refs(store, keys)
-    store = Store.invalidate_refs(store, keys)
+    %{backend: backend} = state
+    store = backend.invalidate(state.store, keys)
+    store = invalidate_hgetall_refs(store, keys, state)
+    store = backend.invalidate_refs(store, keys)
     {:noreply, %{state | store: store}}
   end
 
   def handle_info(:sweep, state) do
-    store = Store.sweep_expired(state.store)
+    store = state.backend.sweep_expired(state.store)
     schedule_sweep(state.sweep_interval)
     {:noreply, %{state | store: store}}
   end
@@ -299,7 +297,7 @@ defmodule Redis.Cache do
       :exit, _ -> :ok
     end
 
-    Store.destroy(state.store)
+    state.backend.destroy(state.store)
 
     try do
       Connection.stop(state.conn)
@@ -312,18 +310,48 @@ defmodule Redis.Cache do
   # Helpers
   # -------------------------------------------------------------------
 
+  defp init_tracking_and_store(conn, tracking_args, opts) do
+    case Connection.command(conn, tracking_args) do
+      {:ok, "OK"} ->
+        case opts.backend.init(opts.store_opts) do
+          {:ok, store} ->
+            state = %__MODULE__{
+              conn: conn,
+              store: store,
+              backend: opts.backend,
+              ttl: opts.ttl,
+              optin: opts.optin,
+              sweep_interval: opts.sweep_interval,
+              cacheable: Allowlist.normalize(opts.cacheable)
+            }
+
+            schedule_sweep(opts.sweep_interval)
+            {:ok, state}
+
+          {:error, reason} ->
+            Connection.stop(conn)
+            {:stop, {:backend_init_failed, reason}}
+        end
+
+      {:error, reason} ->
+        Connection.stop(conn)
+        {:stop, {:tracking_failed, reason}}
+    end
+  end
+
   defp handle_generic_cached([_cmd, redis_key | _] = args, cmd_ttl, state) do
+    %{backend: backend} = state
     cache_key = List.to_tuple(args)
     ttl = cmd_ttl || state.ttl
 
-    case Store.get(state.store, cache_key) do
+    case backend.get(state.store, cache_key) do
       {:hit, value, store} ->
         {:reply, {:ok, value}, %{state | store: store}}
 
       {:miss, store} ->
         case Connection.command(state.conn, args) do
           {:ok, value} ->
-            store = Store.put_with_ref(store, cache_key, redis_key, value, ttl)
+            store = backend.put_with_ref(store, cache_key, redis_key, value, ttl)
             {:reply, {:ok, value}, %{state | store: store}}
 
           error ->
@@ -337,11 +365,13 @@ defmodule Redis.Cache do
   defp normalize_optin_result(result, false), do: result
   defp normalize_optin_result(error, _), do: error
 
-  defp check_cache_for_keys(keys, store) do
+  defp check_cache_for_keys(keys, state) do
+    %{backend: backend} = state
+
     keys
     |> Enum.with_index()
-    |> Enum.reduce({%{}, [], [], store}, fn {key, idx}, {cached, missed_k, missed_i, st} ->
-      case Store.get(st, key) do
+    |> Enum.reduce({%{}, [], [], state.store}, fn {key, idx}, {cached, missed_k, missed_i, st} ->
+      case backend.get(st, key) do
         {:hit, value, st} -> {Map.put(cached, idx, value), missed_k, missed_i, st}
         {:miss, st} -> {cached, [key | missed_k], [idx | missed_i], st}
       end
@@ -349,6 +379,7 @@ defmodule Redis.Cache do
   end
 
   defp fetch_and_merge_mget(keys, cached, missed_keys, missed_indices, store, state) do
+    %{backend: backend} = state
     missed_keys = Enum.reverse(missed_keys)
     missed_indices = Enum.reverse(missed_indices)
 
@@ -357,7 +388,7 @@ defmodule Redis.Cache do
         store =
           Enum.zip(missed_keys, fetched)
           |> Enum.reduce(store, fn {key, value}, st ->
-            Store.put(st, key, value, state.ttl)
+            backend.put(st, key, value, state.ttl)
           end)
 
         fetched_map = Enum.zip(missed_indices, fetched) |> Map.new()
@@ -371,13 +402,15 @@ defmodule Redis.Cache do
     end
   end
 
-  defp invalidate_hgetall_refs(store, nil), do: store
+  defp invalidate_hgetall_refs(store, nil, _state), do: store
 
-  defp invalidate_hgetall_refs(store, keys) do
+  defp invalidate_hgetall_refs(store, keys, state) do
+    %{backend: backend} = state
+
     Enum.reduce(keys, store, fn key, st ->
-      case :ets.lookup(st.table, key) do
-        [{^key, {:hgetall_ref, cache_key}, _, _}] ->
-          Store.invalidate(st, [cache_key])
+      case backend.get(st, key) do
+        {:hit, {:hgetall_ref, cache_key}, st} ->
+          backend.invalidate(st, [cache_key])
 
         _ ->
           st

--- a/lib/redis/cache/store.ex
+++ b/lib/redis/cache/store.ex
@@ -2,15 +2,17 @@ defmodule Redis.Cache.Store do
   @moduledoc """
   ETS-backed cache store for client-side caching.
 
-  Stores key -> value mappings with optional TTL, bounded size, and
-  configurable eviction policy. Tracks hits, misses, and evictions
-  for observability.
+  This is the default implementation of `Redis.Cache.Backend`. Stores
+  key -> value mappings with optional TTL, bounded size, and configurable
+  eviction policy. Tracks hits, misses, and evictions for observability.
 
   ## Options
 
     * `:max_entries` - maximum number of entries (default: `10_000`, `0` for unlimited)
     * `:eviction_policy` - `:lru` or `:fifo` (default: `:lru`)
   """
+
+  @behaviour Redis.Cache.Backend
 
   defstruct [
     :table,
@@ -38,6 +40,14 @@ defmodule Redis.Cache.Store do
           stores: non_neg_integer()
         }
 
+  @doc "Initializes the store from options. Implements `Redis.Cache.Backend.init/1`."
+  @impl true
+  @spec init(keyword()) :: {:ok, t()}
+  def init(opts) do
+    name = Keyword.get(opts, :name, :redis_ex_cache)
+    {:ok, new(name, opts)}
+  end
+
   @doc "Creates a new cache store backed by ETS tables."
   @spec new(atom(), keyword()) :: t()
   def new(name \\ :redis_ex_cache, opts \\ []) do
@@ -60,6 +70,7 @@ defmodule Redis.Cache.Store do
   end
 
   @doc "Gets a value from the cache. Returns `{:hit, value, store}` or `{:miss, store}`."
+  @impl true
   @spec get(t(), term()) :: {:hit, term(), t()} | {:miss, t()}
   def get(%__MODULE__{} = store, key) do
     case :ets.lookup(store.table, key) do
@@ -78,6 +89,7 @@ defmodule Redis.Cache.Store do
   end
 
   @doc "Puts a value in the cache with optional TTL in milliseconds."
+  @impl true
   @spec put(t(), term(), term(), non_neg_integer() | nil) :: t()
   def put(%__MODULE__{} = store, key, value, ttl_ms \\ nil) do
     expires_at =
@@ -104,6 +116,7 @@ defmodule Redis.Cache.Store do
   When `redis_key` is later invalidated via `invalidate_refs/2`, all cache
   entries that reference it are removed.
   """
+  @impl true
   @spec put_with_ref(t(), term(), String.t(), term(), non_neg_integer() | nil) :: t()
   def put_with_ref(%__MODULE__{} = store, cache_key, redis_key, value, ttl_ms \\ nil) do
     store = put(store, cache_key, value, ttl_ms)
@@ -117,6 +130,7 @@ defmodule Redis.Cache.Store do
   Looks up the refs table to find cache keys that depend on each Redis key,
   invalidates them, and cleans up the ref entries.
   """
+  @impl true
   @spec invalidate_refs(t(), [String.t()] | nil) :: t()
   def invalidate_refs(%__MODULE__{} = store, nil), do: store
 
@@ -130,6 +144,7 @@ defmodule Redis.Cache.Store do
   end
 
   @doc "Invalidates one or more keys. Called when Redis pushes invalidation."
+  @impl true
   @spec invalidate(t(), [String.t()] | nil) :: t()
   def invalidate(%__MODULE__{} = store, nil) do
     count = :ets.info(store.table, :size)
@@ -156,6 +171,7 @@ defmodule Redis.Cache.Store do
   end
 
   @doc "Returns cache statistics."
+  @impl true
   @spec stats(t()) :: map()
   def stats(%__MODULE__{} = store) do
     total = store.hits + store.misses
@@ -174,6 +190,7 @@ defmodule Redis.Cache.Store do
   end
 
   @doc "Removes expired entries from the cache."
+  @impl true
   @spec sweep_expired(t()) :: t()
   def sweep_expired(%__MODULE__{} = store) do
     now = System.monotonic_time(:millisecond)
@@ -192,6 +209,7 @@ defmodule Redis.Cache.Store do
   end
 
   @doc "Clears the entire cache."
+  @impl true
   @spec flush(t()) :: t()
   def flush(%__MODULE__{} = store) do
     :ets.delete_all_objects(store.table)
@@ -201,6 +219,7 @@ defmodule Redis.Cache.Store do
   end
 
   @doc "Destroys the cache store (deletes the ETS tables)."
+  @impl true
   @spec destroy(t()) :: :ok
   def destroy(%__MODULE__{table: table, index_table: index_table, refs_table: refs_table}) do
     :ets.delete(table)

--- a/test/integration/cache_backend_test.exs
+++ b/test/integration/cache_backend_test.exs
@@ -1,0 +1,235 @@
+defmodule Redis.Cache.MapBackend do
+  @moduledoc false
+  @behaviour Redis.Cache.Backend
+
+  defstruct [:data, :refs, hits: 0, misses: 0, evictions: 0, stores: 0]
+
+  @impl true
+  def init(_opts) do
+    {:ok, %__MODULE__{data: %{}, refs: %{}}}
+  end
+
+  @impl true
+  def get(%__MODULE__{} = state, key) do
+    case Map.fetch(state.data, key) do
+      {:ok, {value, expires_at}} ->
+        if expired?(expires_at) do
+          state = %{state | data: Map.delete(state.data, key), misses: state.misses + 1}
+          {:miss, state}
+        else
+          {:hit, value, %{state | hits: state.hits + 1}}
+        end
+
+      :error ->
+        {:miss, %{state | misses: state.misses + 1}}
+    end
+  end
+
+  @impl true
+  def put(%__MODULE__{} = state, key, value, ttl_ms) do
+    expires_at = if ttl_ms, do: System.monotonic_time(:millisecond) + ttl_ms
+    %{state | data: Map.put(state.data, key, {value, expires_at}), stores: state.stores + 1}
+  end
+
+  @impl true
+  def put_with_ref(%__MODULE__{} = state, cache_key, redis_key, value, ttl_ms) do
+    state = put(state, cache_key, value, ttl_ms)
+    existing = Map.get(state.refs, redis_key, MapSet.new())
+    %{state | refs: Map.put(state.refs, redis_key, MapSet.put(existing, cache_key))}
+  end
+
+  @impl true
+  def invalidate_refs(%__MODULE__{} = state, nil), do: state
+
+  def invalidate_refs(%__MODULE__{} = state, keys) do
+    Enum.reduce(keys, state, fn redis_key, st ->
+      cache_keys = Map.get(st.refs, redis_key, MapSet.new())
+      st = evict_cache_keys(st, cache_keys)
+      %{st | refs: Map.delete(st.refs, redis_key)}
+    end)
+  end
+
+  defp evict_cache_keys(state, cache_keys) do
+    Enum.reduce(cache_keys, state, fn ck, inner ->
+      if Map.has_key?(inner.data, ck) do
+        %{inner | data: Map.delete(inner.data, ck), evictions: inner.evictions + 1}
+      else
+        inner
+      end
+    end)
+  end
+
+  @impl true
+  def invalidate(%__MODULE__{} = state, nil) do
+    count = map_size(state.data)
+    %{state | data: %{}, refs: %{}, evictions: state.evictions + count}
+  end
+
+  def invalidate(%__MODULE__{} = state, keys) do
+    Enum.reduce(keys, state, fn key, st ->
+      if Map.has_key?(st.data, key) do
+        %{st | data: Map.delete(st.data, key), evictions: st.evictions + 1}
+      else
+        st
+      end
+    end)
+  end
+
+  @impl true
+  def stats(%__MODULE__{} = state) do
+    total = state.hits + state.misses
+    hit_rate = if total > 0, do: Float.round(state.hits / total * 100, 1), else: 0.0
+
+    %{
+      hits: state.hits,
+      misses: state.misses,
+      evictions: state.evictions,
+      stores: state.stores,
+      size: map_size(state.data),
+      hit_rate: hit_rate
+    }
+  end
+
+  @impl true
+  def sweep_expired(%__MODULE__{} = state) do
+    now = System.monotonic_time(:millisecond)
+
+    {kept, evicted_count} =
+      Enum.reduce(state.data, {%{}, 0}, fn {key, {_val, exp} = entry}, {acc, count} ->
+        if exp != nil and exp < now do
+          {acc, count + 1}
+        else
+          {Map.put(acc, key, entry), count}
+        end
+      end)
+
+    %{state | data: kept, evictions: state.evictions + evicted_count}
+  end
+
+  @impl true
+  def flush(%__MODULE__{} = state) do
+    %{state | data: %{}, refs: %{}}
+  end
+
+  @impl true
+  def destroy(%__MODULE__{}), do: :ok
+
+  defp expired?(nil), do: false
+  defp expired?(exp), do: System.monotonic_time(:millisecond) > exp
+end
+
+defmodule Redis.Cache.BackendIntegrationTest do
+  use ExUnit.Case, async: false
+
+  alias Redis.Cache
+  alias Redis.Connection
+
+  describe "custom backend" do
+    test "caches GET results using MapBackend" do
+      {:ok, cache} = Cache.start_link(port: 6398, backend: Redis.Cache.MapBackend)
+
+      Cache.command(cache, ["SET", "be_test", "hello"])
+
+      # Miss
+      assert {:ok, "hello"} = Cache.get(cache, "be_test")
+      stats = Cache.stats(cache)
+      assert stats.misses == 1
+
+      # Hit
+      assert {:ok, "hello"} = Cache.get(cache, "be_test")
+      stats = Cache.stats(cache)
+      assert stats.hits == 1
+
+      Cache.command(cache, ["DEL", "be_test"])
+      Cache.stop(cache)
+    end
+
+    test "invalidation works with MapBackend" do
+      {:ok, cache} = Cache.start_link(port: 6398, backend: Redis.Cache.MapBackend)
+
+      Cache.command(cache, ["SET", "be_inv", "original"])
+      Cache.get(cache, "be_inv")
+      Cache.get(cache, "be_inv")
+
+      # Modify via separate connection
+      {:ok, other} = Connection.start_link(port: 6398)
+      Connection.command(other, ["SET", "be_inv", "modified"])
+      Process.sleep(200)
+
+      assert {:ok, "modified"} = Cache.get(cache, "be_inv")
+
+      stats = Cache.stats(cache)
+      assert stats.evictions >= 1
+
+      Connection.stop(other)
+      Cache.command(cache, ["DEL", "be_inv"])
+      Cache.stop(cache)
+    end
+
+    test "cached_command works with MapBackend" do
+      {:ok, cache} = Cache.start_link(port: 6398, backend: Redis.Cache.MapBackend)
+
+      Cache.command(cache, ["RPUSH", "be_list", "a", "b", "c"])
+
+      assert {:ok, 3} = Cache.cached_command(cache, ["LLEN", "be_list"])
+      assert {:ok, 3} = Cache.cached_command(cache, ["LLEN", "be_list"])
+
+      stats = Cache.stats(cache)
+      assert stats.hits >= 1
+
+      Cache.command(cache, ["DEL", "be_list"])
+      Cache.stop(cache)
+    end
+
+    test "MGET works with MapBackend" do
+      {:ok, cache} = Cache.start_link(port: 6398, backend: Redis.Cache.MapBackend)
+
+      Cache.command(cache, ["SET", "be_m1", "x"])
+      Cache.command(cache, ["SET", "be_m2", "y"])
+
+      Cache.get(cache, "be_m1")
+      assert {:ok, ["x", "y"]} = Cache.mget(cache, ["be_m1", "be_m2"])
+
+      stats = Cache.stats(cache)
+      assert stats.hits >= 1
+
+      Cache.command(cache, ["DEL", "be_m1", "be_m2"])
+      Cache.stop(cache)
+    end
+
+    test "flush works with MapBackend" do
+      {:ok, cache} = Cache.start_link(port: 6398, backend: Redis.Cache.MapBackend)
+
+      Cache.command(cache, ["SET", "be_flush", "val"])
+      Cache.get(cache, "be_flush")
+
+      stats = Cache.stats(cache)
+      assert stats.size == 1
+
+      Cache.flush(cache)
+
+      stats = Cache.stats(cache)
+      assert stats.size == 0
+
+      Cache.command(cache, ["DEL", "be_flush"])
+      Cache.stop(cache)
+    end
+
+    test "stats works with MapBackend" do
+      {:ok, cache} = Cache.start_link(port: 6398, backend: Redis.Cache.MapBackend)
+
+      Cache.command(cache, ["SET", "be_st", "val"])
+      Cache.get(cache, "be_st")
+      Cache.get(cache, "be_st")
+      Cache.get(cache, "be_st")
+
+      stats = Cache.stats(cache)
+      assert stats.misses >= 1
+      assert stats.hits >= 2
+      assert stats.hit_rate > 50.0
+
+      Cache.command(cache, ["DEL", "be_st"])
+      Cache.stop(cache)
+    end
+  end
+end

--- a/test/unit/cache/backend_test.exs
+++ b/test/unit/cache/backend_test.exs
@@ -1,0 +1,64 @@
+defmodule Redis.Cache.BackendTest do
+  use ExUnit.Case, async: true
+
+  alias Redis.Cache.Store
+
+  describe "Store implements Backend behaviour" do
+    test "init/1 returns {:ok, store}" do
+      {:ok, store} = Store.init(max_entries: 100, eviction_policy: :fifo)
+
+      assert %Store{} = store
+      assert store.max_entries == 100
+      assert store.eviction_policy == :fifo
+
+      Store.destroy(store)
+    end
+
+    test "init/1 with custom name" do
+      {:ok, store} = Store.init(name: :custom_backend_test)
+
+      assert %Store{} = store
+
+      Store.destroy(store)
+    end
+
+    test "full lifecycle through behaviour callbacks" do
+      {:ok, store} = Store.init(max_entries: 5)
+
+      # put and get
+      store = Store.put(store, "k1", "v1", nil)
+      assert {:hit, "v1", store} = Store.get(store, "k1")
+
+      # put_with_ref and invalidate_refs
+      store = Store.put_with_ref(store, {:cmd, "k2"}, "k2", "v2", nil)
+      assert {:hit, "v2", store} = Store.get(store, {:cmd, "k2"})
+      store = Store.invalidate_refs(store, ["k2"])
+      assert {:miss, store} = Store.get(store, {:cmd, "k2"})
+
+      # invalidate
+      store = Store.put(store, "k3", "v3", nil)
+      store = Store.invalidate(store, ["k3"])
+      assert {:miss, store} = Store.get(store, "k3")
+
+      # stats
+      stats = Store.stats(store)
+      assert is_map(stats)
+      assert Map.has_key?(stats, :hits)
+      assert Map.has_key?(stats, :misses)
+
+      # sweep_expired
+      store = Store.put(store, "exp", "val", 1)
+      Process.sleep(10)
+      store = Store.sweep_expired(store)
+      assert {:miss, store} = Store.get(store, "exp")
+
+      # flush
+      store = Store.put(store, "f1", "v1", nil)
+      store = Store.flush(store)
+      assert {:miss, _store} = Store.get(store, "f1")
+
+      # destroy
+      assert :ok = Store.destroy(store)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Define `Redis.Cache.Backend` behaviour with 10 callbacks covering the full cache lifecycle
- Make `Redis.Cache.Store` implement the behaviour (with `@impl true` on all callbacks)
- Dispatch all store operations in `Redis.Cache` through the configured backend module
- Includes a complete `MapBackend` test implementation proving the interface works end-to-end

## New Options

| Option | Default | Description |
|--------|---------|-------------|
| `:backend` | `Redis.Cache.Store` | Module implementing `Redis.Cache.Backend` |
| `:backend_opts` | `[]` | Additional opts passed to `backend.init/1` |

## Example

```elixir
# Default (unchanged behavior)
Redis.Cache.start_link(port: 6379)

# Custom backend
Redis.Cache.start_link(
  port: 6379,
  backend: MyApp.CachexBackend,
  backend_opts: [name: :my_cache]
)
```

## Test plan

- [x] 3 unit tests verifying Store implements Backend correctly (init, lifecycle)
- [x] 6 integration tests using a pure-Map backend (GET, invalidation, cached_command, MGET, flush, stats)
- [x] All 65 existing cache tests pass unchanged
- [x] 74 total tests, 0 failures

Closes #96