### PR TITLE
fix: consumer XREADGROUP timeout and resilience compile error

### DIFF
--- a/lib/redis/consumer.ex
+++ b/lib/redis/consumer.ex
@@ -241,7 +241,7 @@ defmodule Redis.Consumer do
         block: state.block
       )
 
-    Connection.command(state.conn, cmd)
+    Connection.command(state.conn, cmd, timeout: state.block + 5_000)
   end
 
   defp process_messages(state, messages) do

--- a/lib/redis/resilience/resilience.ex
+++ b/lib/redis/resilience/resilience.ex
@@ -307,6 +307,8 @@ defmodule Redis.Resilience do
     end
 
     defp call_through_pipeline(_, _, _), do: {:error, :ex_resilience_not_available}
+
+    defp stop_pipeline(_state), do: :ok
   end
 
   defp safe_stop(pid) do


### PR DESCRIPTION
## Summary

Two fixes found while building the LiveView demo app:

### 1. Consumer XREADGROUP timeout race

`Redis.Consumer` uses `XREADGROUP ... BLOCK 5000` but the `Connection.command/3` call used the default 5000ms GenServer timeout. When Redis blocks for the full duration, the GenServer.call times out first, crashing the consumer.

**Fix:** Pass `timeout: state.block + 5_000` to give the call enough headroom.

### 2. Resilience compile error without ex_resilience

`stop_pipeline/1` was only defined inside the `if @ex_resilience_available` conditional block, but `terminate/2` calls it unconditionally. When `ex_resilience` isn't a dependency, the module fails to compile.

**Fix:** Add a no-op `defp stop_pipeline(_state), do: :ok` in the `else` branch.

## Test plan

- [ ] Consumer with `block: 5000` no longer crashes with GenServer timeout
- [ ] `mix compile` succeeds without `ex_resilience` in deps
- [ ] `mix compile` succeeds with `ex_resilience` in deps