### PR TITLE
Add primary/replica read routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,13 +165,38 @@ Redis.Cluster.transaction(cluster, [
 {:ok, conn} = Redis.Sentinel.start_link(
   sentinels: [{"sentinel1", 26379}, {"sentinel2", 26379}],
   group: "mymaster",
-  role: :primary,
+  read_preference: :prefer_replica,
   password: "secret"
 )
 
-# Transparently resolves master, reconnects on failover
+# Writes use the primary; eligible reads prefer replicas
 Redis.Sentinel.command(conn, ["SET", "key", "value"])
+Redis.Sentinel.command(conn, ["GET", "key"])
 ```
+
+Sentinel refreshes both primary and replica topology and reconnects on
+failover. The existing `role: :primary | :replica` option remains available
+for a fixed-role connection.
+
+## Primary/Replica Routing
+
+For a manually managed replica set, configure the primary and optional
+replicas directly:
+
+```elixir
+{:ok, redis} = Redis.ReplicaSet.start_link(
+  primary: {"redis-primary", 6379},
+  replicas: [{"redis-replica-1", 6379}, {"redis-replica-2", 6379}],
+  read_preference: :prefer_replica
+)
+
+Redis.ReplicaSet.command(redis, ["SET", "key", "value"]) # primary
+Redis.ReplicaSet.command(redis, ["GET", "key"])          # replica, then primary fallback
+```
+
+Omit `:replicas` to discover online replicas from `INFO REPLICATION`.
+Read-only commands are derived from Redis `COMMAND` metadata; unknown
+commands, writes, mixed pipelines, and transactions stay on the primary.
 
 ## Pub/Sub
 
@@ -390,6 +415,7 @@ Redis.Resilience.command(conn, ["GET", "key"])
 - **RESP3 native** with RESP2 fallback for older servers
 - **Cluster** with topology discovery, hash slot routing, MOVED/ASK redirects, cross-slot pipeline splitting, transaction validation
 - **Sentinel** with master resolution, role verification, proactive failover via `+switch-master`
+- **Primary/replica routing** with Sentinel and INFO topology discovery
 - **Pub/Sub** with pattern subscriptions, sharded pub/sub (Redis 7+)
 - **Structured command monitoring** with subscriber filters and cleanup
 - **Phoenix.PubSub adapter** for cross-node broadcasting (optional dep)

--- a/lib/redis.ex
+++ b/lib/redis.ex
@@ -7,6 +7,7 @@ defmodule Redis do
 
     * `Redis.Connection` - single connection with full options
     * `Redis.Connection.Pool` - connection pooling
+    * `Redis.ReplicaSet` - primary/replica read routing
     * `Redis.Cluster` - cluster-aware client with slot routing
     * `Redis.Sentinel` - sentinel-aware client with failover
     * `Redis.PubSub` - pub/sub subscriptions

--- a/lib/redis/replica_set.ex
+++ b/lib/redis/replica_set.ex
@@ -1,0 +1,669 @@
+defmodule Redis.ReplicaSet do
+  @moduledoc """
+  Routes writes to a Redis primary and eligible reads to replicas.
+
+  `Redis.ReplicaSet` can use explicitly configured replicas:
+
+      {:ok, redis} = Redis.ReplicaSet.start_link(
+        primary: {"redis-primary", 6379},
+        replicas: [{"redis-replica-1", 6379}, {"redis-replica-2", 6379}],
+        read_preference: :prefer_replica
+      )
+
+  When `:replicas` is omitted, the process discovers online replicas from the
+  primary's `INFO REPLICATION` response and periodically refreshes them:
+
+      Redis.ReplicaSet.start_link(
+        primary: "redis://redis-primary:6379",
+        read_preference: :replica
+      )
+
+  Redis' `COMMAND` metadata determines which commands are read-only. Unknown
+  commands are routed to the primary. Module or application-specific commands
+  can be added with `:read_only_commands`.
+
+  ## Read preferences
+
+    * `:master` (default) - route every command to the primary
+    * `:replica` - route reads to replicas. If replicas are configured but all
+      fail, return the replica error. If none are available, use the primary.
+    * `:prefer_replica` - route reads to replicas and fall back to the primary
+      when replica execution fails
+
+  Writes, mixed pipelines, transactions, and unknown commands always use the
+  primary. Reads are distributed round-robin across connected replicas.
+
+  ## Options
+
+    * `:primary` - primary node as `{host, port}`, `"host:port"`, Redis URI, or
+      connection keyword list (required)
+    * `:replicas` - explicit list of replica nodes; omit for INFO discovery
+    * `:read_preference` - `:master`, `:replica`, or `:prefer_replica`
+    * `:read_only_commands` - extra command names that are safe on replicas
+    * `:topology_refresh_interval` - INFO refresh interval in milliseconds
+      (default: 30_000; applies only to discovered topology)
+
+  Normal `Redis.Connection` options such as authentication, TLS, protocol,
+  database, credential provider, and timeout are shared by all nodes. A node
+  expressed as a keyword list or URI may override shared options.
+  """
+
+  use GenServer
+
+  alias Redis.Connection
+  alias Redis.ReplicaSet.{CommandMetadata, Topology}
+
+  require Logger
+
+  @connection_option_keys [
+    :password,
+    :username,
+    :database,
+    :ssl,
+    :ssl_opts,
+    :protocol,
+    :timeout,
+    :credential_provider,
+    :client_name
+  ]
+  @read_preferences [:master, :replica, :prefer_replica]
+
+  defstruct [
+    :primary,
+    :primary_spec,
+    :read_commands,
+    :read_preference,
+    :connection_opts,
+    :timeout,
+    :topology_refresh_interval,
+    replica_specs: %{},
+    replicas: %{},
+    replica_order: [],
+    next_replica: 0,
+    discover_replicas: false,
+    extra_read_commands: []
+  ]
+
+  @type node_spec ::
+          {String.t(), non_neg_integer()}
+          | String.t()
+          | keyword()
+
+  # -------------------------------------------------------------------
+  # Public API
+  # -------------------------------------------------------------------
+
+  @doc "Returns a child specification for a replica-set router."
+  @spec child_spec(keyword()) :: Supervisor.child_spec()
+  def child_spec(opts) do
+    %{
+      id: Keyword.get(opts, :name, __MODULE__),
+      start: {__MODULE__, :start_link, [opts]},
+      type: :worker,
+      restart: :permanent
+    }
+  end
+
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts) do
+    {name, opts} = Keyword.pop(opts, :name)
+    gen_opts = if name, do: [name: name], else: []
+    GenServer.start_link(__MODULE__, opts, gen_opts)
+  end
+
+  @doc "Routes a command according to its mutability and the configured read preference."
+  @spec command(GenServer.server(), [term()], keyword()) :: {:ok, term()} | {:error, term()}
+  def command(replica_set, arguments, opts \\ []) do
+    GenServer.call(replica_set, {:command, arguments}, call_timeout(opts))
+  end
+
+  @doc "Routes an all-read pipeline to a replica and every other pipeline to the primary."
+  @spec pipeline(GenServer.server(), [[term()]], keyword()) ::
+          {:ok, [term()]} | {:error, term()}
+  def pipeline(replica_set, commands, opts \\ []) do
+    GenServer.call(replica_set, {:pipeline, commands}, call_timeout(opts))
+  end
+
+  @doc "Executes a transaction on the primary."
+  @spec transaction(GenServer.server(), [[term()]], keyword()) ::
+          {:ok, [term()]} | {:error, term()}
+  def transaction(replica_set, commands, opts \\ []) do
+    GenServer.call(replica_set, {:transaction, commands}, call_timeout(opts))
+  end
+
+  @doc "Replaces the primary and replica addresses without restarting the router."
+  @spec update_topology(GenServer.server(), node_spec(), [node_spec()]) ::
+          :ok | {:error, term()}
+  def update_topology(replica_set, primary, replicas) do
+    GenServer.call(replica_set, {:update_topology, primary, replicas}, 30_000)
+  end
+
+  @doc "Refreshes replica connections and INFO-discovered topology."
+  @spec refresh(GenServer.server()) :: :ok | {:error, term()}
+  def refresh(replica_set), do: GenServer.call(replica_set, :refresh, 30_000)
+
+  @doc "Returns the current routing and topology state."
+  @spec info(GenServer.server()) :: map()
+  def info(replica_set), do: GenServer.call(replica_set, :info)
+
+  @doc "Stops the replica-set router and all of its connections."
+  @spec stop(GenServer.server()) :: :ok
+  def stop(replica_set), do: GenServer.stop(replica_set, :normal)
+
+  # -------------------------------------------------------------------
+  # GenServer callbacks
+  # -------------------------------------------------------------------
+
+  @impl true
+  def init(opts) do
+    Process.flag(:trap_exit, true)
+
+    with {:ok, read_preference} <- validate_read_preference(opts),
+         {:ok, primary_spec} <- opts |> Keyword.fetch!(:primary) |> normalize_node(),
+         {:ok, configured_replicas} <- normalize_nodes(Keyword.get(opts, :replicas, [])),
+         connection_opts = Keyword.take(opts, @connection_option_keys),
+         timeout = Keyword.get(opts, :timeout, 5_000),
+         {:ok, primary} <- connect_node(primary_spec, connection_opts, :primary, timeout) do
+      extra_read_commands = Keyword.get(opts, :read_only_commands, [])
+      discover_replicas = not Keyword.has_key?(opts, :replicas)
+
+      replica_specs =
+        initial_replica_specs(
+          primary,
+          configured_replicas,
+          discover_replicas,
+          timeout
+        )
+
+      state = %__MODULE__{
+        primary: primary,
+        primary_spec: primary_spec,
+        read_commands: CommandMetadata.fetch(primary, extra_read_commands, timeout),
+        read_preference: read_preference,
+        connection_opts: connection_opts,
+        timeout: timeout,
+        topology_refresh_interval: Keyword.get(opts, :topology_refresh_interval, 30_000),
+        discover_replicas: discover_replicas,
+        extra_read_commands: extra_read_commands
+      }
+
+      state = reconcile_replicas(state, replica_specs)
+      state = schedule_topology_refresh(state)
+      {:ok, state}
+    else
+      {:error, reason} -> {:stop, reason}
+    end
+  end
+
+  @impl true
+  def handle_call({:command, arguments}, _from, state) do
+    if CommandMetadata.read_only?(state.read_commands, arguments) do
+      {result, state} = execute_read(state, :command, arguments)
+      {:reply, result, state}
+    else
+      {:reply, execute_primary(state, :command, arguments), state}
+    end
+  end
+
+  def handle_call({:pipeline, []}, _from, state), do: {:reply, {:ok, []}, state}
+
+  def handle_call({:pipeline, commands}, _from, state) do
+    if Enum.all?(commands, &CommandMetadata.read_only?(state.read_commands, &1)) do
+      {result, state} = execute_read(state, :pipeline, commands)
+      {:reply, result, state}
+    else
+      {:reply, execute_primary(state, :pipeline, commands), state}
+    end
+  end
+
+  def handle_call({:transaction, commands}, _from, state) do
+    {:reply, execute_primary(state, :transaction, commands), state}
+  end
+
+  def handle_call({:update_topology, primary, replicas}, _from, state) do
+    with {:ok, primary_spec} <- normalize_node(primary),
+         {:ok, replica_specs} <- normalize_nodes(replicas),
+         {:ok, state} <- replace_topology(state, primary_spec, replica_specs) do
+      {:reply, :ok, state}
+    else
+      {:error, reason} -> {:reply, {:error, reason}, state}
+    end
+  end
+
+  def handle_call(:refresh, _from, state) do
+    case refresh_topology(state) do
+      {:ok, state} -> {:reply, :ok, state}
+      {:error, reason, state} -> {:reply, {:error, reason}, state}
+    end
+  end
+
+  def handle_call(:info, _from, state) do
+    info = %{
+      primary: node_key(state.primary_spec),
+      replicas: Map.keys(state.replica_specs),
+      connected_replicas: Map.keys(state.replicas),
+      read_preference: state.read_preference,
+      discovery: if(state.discover_replicas, do: :info, else: :configured)
+    }
+
+    {:reply, info, state}
+  end
+
+  @impl true
+  def handle_info(:refresh_topology, state) do
+    state =
+      case refresh_topology(state) do
+        {:ok, state} ->
+          state
+
+        {:error, reason, state} ->
+          Logger.warning("Redis.ReplicaSet: topology refresh failed: #{inspect(reason)}")
+          state
+      end
+
+    {:noreply, schedule_topology_refresh(state)}
+  end
+
+  def handle_info(:reconnect_primary, %{primary: nil} = state) do
+    case connect_node(state.primary_spec, state.connection_opts, :primary, state.timeout) do
+      {:ok, primary} ->
+        read_commands =
+          CommandMetadata.fetch(primary, state.extra_read_commands, state.timeout)
+
+        {:noreply, %{state | primary: primary, read_commands: read_commands}}
+
+      {:error, _reason} ->
+        Process.send_after(self(), :reconnect_primary, 500)
+        {:noreply, state}
+    end
+  end
+
+  def handle_info(:reconnect_primary, state), do: {:noreply, state}
+
+  def handle_info({:EXIT, pid, reason}, %{primary: pid} = state) do
+    if reason != :normal do
+      Logger.warning("Redis.ReplicaSet: primary connection exited: #{inspect(reason)}")
+    end
+
+    Process.send_after(self(), :reconnect_primary, 0)
+    {:noreply, %{state | primary: nil}}
+  end
+
+  def handle_info({:EXIT, pid, reason}, state) do
+    case Enum.find(state.replicas, fn {_address, connection} -> connection == pid end) do
+      {address, ^pid} ->
+        if reason != :normal do
+          Logger.warning(
+            "Redis.ReplicaSet: replica connection #{inspect(address)} exited: #{inspect(reason)}"
+          )
+        end
+
+        replicas = Map.delete(state.replicas, address)
+        order = Enum.reject(state.replica_order, &(&1 == address))
+        Process.send_after(self(), :reconnect_replicas, 0)
+        {:noreply, %{state | replicas: replicas, replica_order: order}}
+
+      nil ->
+        {:noreply, state}
+    end
+  end
+
+  def handle_info(:reconnect_replicas, state) do
+    {:noreply, reconcile_replicas(state, state.replica_specs)}
+  end
+
+  def handle_info(_message, state), do: {:noreply, state}
+
+  @impl true
+  def terminate(_reason, state) do
+    stop_connection(state.primary)
+    Enum.each(state.replicas, fn {_address, connection} -> stop_connection(connection) end)
+    :ok
+  end
+
+  # -------------------------------------------------------------------
+  # Routing
+  # -------------------------------------------------------------------
+
+  defp execute_read(%{read_preference: :master} = state, operation, payload) do
+    {execute_primary(state, operation, payload), state}
+  end
+
+  defp execute_read(state, operation, payload) do
+    {candidates, state} = replica_candidates(state)
+
+    case try_replicas(candidates, operation, payload, state.timeout) do
+      {:result, result} ->
+        {result, state}
+
+      :no_replicas ->
+        {execute_primary(state, operation, payload), state}
+
+      {:failed, last_error} when state.read_preference == :prefer_replica ->
+        _ = last_error
+        {execute_primary(state, operation, payload), state}
+
+      {:failed, last_error} ->
+        {last_error, state}
+    end
+  end
+
+  defp execute_primary(%{primary: nil}, _operation, _payload),
+    do: {:error, %Redis.ConnectionError{reason: :not_connected}}
+
+  defp execute_primary(state, operation, payload) do
+    safe_execute(state.primary, operation, payload, state.timeout)
+  end
+
+  defp replica_candidates(%{replica_order: []} = state), do: {[], state}
+
+  defp replica_candidates(state) do
+    count = length(state.replica_order)
+    index = rem(state.next_replica, count)
+    {left, right} = Enum.split(state.replica_order, index)
+    addresses = right ++ left
+
+    candidates =
+      Enum.flat_map(addresses, fn address ->
+        case Map.fetch(state.replicas, address) do
+          {:ok, connection} -> [connection]
+          :error -> []
+        end
+      end)
+
+    {candidates, %{state | next_replica: rem(index + 1, count)}}
+  end
+
+  defp try_replicas([], _operation, _payload, _timeout), do: :no_replicas
+
+  defp try_replicas(candidates, operation, payload, timeout) do
+    Enum.reduce_while(candidates, :no_replicas, fn connection, _last_error ->
+      case safe_execute(connection, operation, payload, timeout) do
+        {:error, %Redis.ConnectionError{}} = error -> {:cont, {:failed, error}}
+        result -> {:halt, {:result, result}}
+      end
+    end)
+  end
+
+  defp safe_execute(connection, :command, arguments, timeout),
+    do: safe_call(fn -> Connection.command(connection, arguments, timeout: timeout) end)
+
+  defp safe_execute(connection, :pipeline, commands, timeout),
+    do: safe_call(fn -> Connection.pipeline(connection, commands, timeout: timeout) end)
+
+  defp safe_execute(connection, :transaction, commands, timeout),
+    do: safe_call(fn -> Connection.transaction(connection, commands, timeout: timeout) end)
+
+  defp safe_call(function) do
+    function.()
+  catch
+    :exit, _reason -> {:error, %Redis.ConnectionError{reason: :connection_exited}}
+  end
+
+  # -------------------------------------------------------------------
+  # Topology
+  # -------------------------------------------------------------------
+
+  defp initial_replica_specs(primary, _configured, true, timeout) do
+    case Topology.discover(primary, timeout) do
+      {:ok, replicas} ->
+        normalize_nodes!(replicas)
+
+      {:error, reason} ->
+        Logger.warning("Redis.ReplicaSet: INFO replica discovery failed: #{inspect(reason)}")
+        %{}
+    end
+  end
+
+  defp initial_replica_specs(_primary, configured, false, _timeout),
+    do: specs_by_key(configured)
+
+  defp refresh_topology(%{discover_replicas: true, primary: primary} = state)
+       when primary != nil do
+    case Topology.discover(primary, state.timeout) do
+      {:ok, replicas} ->
+        {:ok, reconcile_replicas(state, normalize_nodes!(replicas))}
+
+      {:error, reason} ->
+        {:error, reason, reconcile_replicas(state, state.replica_specs)}
+    end
+  end
+
+  defp refresh_topology(state),
+    do: {:ok, reconcile_replicas(state, state.replica_specs)}
+
+  defp replace_topology(state, primary_spec, replica_specs) do
+    replica_specs = specs_by_key(replica_specs)
+
+    if node_key(primary_spec) == node_key(state.primary_spec) and state.primary != nil do
+      {:ok, reconcile_replicas(state, replica_specs)}
+    else
+      with {:ok, primary} <-
+             connect_node(primary_spec, state.connection_opts, :primary, state.timeout) do
+        old_primary = state.primary
+
+        state =
+          %{
+            state
+            | primary: primary,
+              primary_spec: primary_spec,
+              read_commands:
+                CommandMetadata.fetch(primary, state.extra_read_commands, state.timeout)
+          }
+          |> reconcile_replicas(replica_specs)
+
+        stop_connection(old_primary)
+        {:ok, state}
+      end
+    end
+  end
+
+  defp reconcile_replicas(state, desired_specs) do
+    desired_specs =
+      desired_specs
+      |> specs_by_key()
+      |> Map.delete(node_key(state.primary_spec))
+
+    desired_keys = Map.keys(desired_specs) |> MapSet.new()
+
+    {kept, stale} =
+      Map.split_with(state.replicas, fn {address, _connection} ->
+        MapSet.member?(desired_keys, address)
+      end)
+
+    Enum.each(stale, fn {_address, connection} -> stop_connection(connection) end)
+
+    replicas =
+      Enum.reduce(
+        desired_specs,
+        kept,
+        &ensure_replica_connection(&1, &2, state)
+      )
+
+    order = desired_specs |> Map.keys() |> Enum.filter(&Map.has_key?(replicas, &1)) |> Enum.sort()
+
+    %{
+      state
+      | replica_specs: desired_specs,
+        replicas: replicas,
+        replica_order: order,
+        next_replica: normalize_index(state.next_replica, length(order))
+    }
+  end
+
+  defp ensure_replica_connection({address, _spec}, connections, _state)
+       when is_map_key(connections, address),
+       do: connections
+
+  defp ensure_replica_connection({address, spec}, connections, state) do
+    case connect_node(spec, state.connection_opts, :replica, state.timeout) do
+      {:ok, connection} ->
+        Map.put(connections, address, connection)
+
+      {:error, reason} ->
+        Logger.warning(
+          "Redis.ReplicaSet: replica #{inspect(address)} unavailable: #{inspect(reason)}"
+        )
+
+        connections
+    end
+  end
+
+  defp connect_node(spec, shared_opts, expected_role, timeout) do
+    opts = Keyword.merge(shared_opts, spec)
+
+    with {:ok, connection} <- Connection.start_link(opts),
+         :ok <- verify_role(connection, expected_role, timeout) do
+      {:ok, connection}
+    else
+      {:error, {:wrong_role, _actual} = reason} ->
+        {:error, reason}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp verify_role(connection, expected_role, timeout) do
+    case Connection.command(connection, ["ROLE"], timeout: timeout) do
+      {:ok, [role | _rest]} ->
+        actual_role = normalize_role(role)
+
+        if actual_role == expected_role do
+          :ok
+        else
+          stop_connection(connection)
+          {:error, {:wrong_role, actual_role}}
+        end
+
+      {:error, reason} ->
+        stop_connection(connection)
+        {:error, reason}
+
+      _unexpected ->
+        stop_connection(connection)
+        {:error, :role_verification_failed}
+    end
+  end
+
+  defp normalize_role("master"), do: :primary
+  defp normalize_role("primary"), do: :primary
+  defp normalize_role("slave"), do: :replica
+  defp normalize_role("replica"), do: :replica
+  defp normalize_role(_role), do: :unknown
+
+  # -------------------------------------------------------------------
+  # Node options
+  # -------------------------------------------------------------------
+
+  defp validate_read_preference(opts) do
+    case Keyword.get(opts, :read_preference, :master) do
+      preference when preference in @read_preferences -> {:ok, preference}
+      :primary -> {:ok, :master}
+      invalid -> {:error, {:invalid_read_preference, invalid}}
+    end
+  end
+
+  defp normalize_nodes(nodes) when is_list(nodes) do
+    Enum.reduce_while(nodes, {:ok, []}, fn node, {:ok, normalized} ->
+      case normalize_node(node) do
+        {:ok, spec} -> {:cont, {:ok, [spec | normalized]}}
+        {:error, reason} -> {:halt, {:error, reason}}
+      end
+    end)
+    |> case do
+      {:ok, normalized} -> {:ok, Enum.reverse(normalized)}
+      error -> error
+    end
+  end
+
+  defp normalize_nodes(_nodes), do: {:error, :invalid_replicas}
+
+  defp normalize_nodes!(nodes) do
+    case normalize_nodes(nodes) do
+      {:ok, specs} -> specs_by_key(specs)
+      {:error, _reason} -> %{}
+    end
+  end
+
+  defp normalize_node({host, port})
+       when (is_binary(host) or is_list(host)) and port in 1..65_535 do
+    {:ok, [host: to_string(host), port: port]}
+  end
+
+  defp normalize_node("redis://" <> _rest = uri), do: {:ok, Redis.URI.parse(uri)}
+  defp normalize_node("rediss://" <> _rest = uri), do: {:ok, Redis.URI.parse(uri)}
+  defp normalize_node("valkey://" <> _rest = uri), do: {:ok, Redis.URI.parse(uri)}
+
+  defp normalize_node(address) when is_binary(address) do
+    case String.split(address, ":", parts: 2) do
+      [host, port] ->
+        case Integer.parse(port) do
+          {port, ""} when port in 1..65_535 -> {:ok, [host: host, port: port]}
+          _ -> {:error, {:invalid_node, address}}
+        end
+
+      [host] when host != "" ->
+        {:ok, [host: host, port: 6379]}
+
+      _ ->
+        {:error, {:invalid_node, address}}
+    end
+  end
+
+  defp normalize_node(opts) when is_list(opts) do
+    if Keyword.keyword?(opts) do
+      cond do
+        is_binary(Keyword.get(opts, :socket)) ->
+          {:ok, opts}
+
+        (is_binary(Keyword.get(opts, :host)) or is_list(Keyword.get(opts, :host))) and
+            Keyword.get(opts, :port, 6379) in 1..65_535 ->
+          {:ok, Keyword.put_new(opts, :port, 6379)}
+
+        true ->
+          {:error, {:invalid_node, opts}}
+      end
+    else
+      {:error, {:invalid_node, opts}}
+    end
+  end
+
+  defp normalize_node(node), do: {:error, {:invalid_node, node}}
+
+  defp specs_by_key(specs) when is_map(specs), do: specs
+  defp specs_by_key(specs), do: Map.new(specs, &{node_key(&1), &1})
+
+  defp node_key(spec) do
+    case Keyword.get(spec, :socket) do
+      nil -> {to_string(Keyword.get(spec, :host, "127.0.0.1")), Keyword.get(spec, :port, 6379)}
+      socket -> {:local, socket}
+    end
+  end
+
+  # -------------------------------------------------------------------
+  # Helpers
+  # -------------------------------------------------------------------
+
+  defp call_timeout(opts), do: Keyword.get(opts, :timeout, 10_000)
+
+  defp schedule_topology_refresh(state) do
+    if state.discover_replicas and is_integer(state.topology_refresh_interval) and
+         state.topology_refresh_interval > 0 do
+      Process.send_after(self(), :refresh_topology, state.topology_refresh_interval)
+    end
+
+    state
+  end
+
+  defp normalize_index(_index, 0), do: 0
+  defp normalize_index(index, count), do: rem(index, count)
+
+  defp stop_connection(nil), do: :ok
+
+  defp stop_connection(connection) do
+    Connection.stop(connection)
+  catch
+    :exit, _reason -> :ok
+  end
+end

--- a/lib/redis/replica_set/command_metadata.ex
+++ b/lib/redis/replica_set/command_metadata.ex
@@ -1,0 +1,85 @@
+defmodule Redis.ReplicaSet.CommandMetadata do
+  @moduledoc false
+
+  alias Redis.Connection
+
+  # Used only when COMMAND is unavailable (for example, because an ACL denies it).
+  # Redis' own command metadata is the source of truth during normal operation.
+  @fallback_read_only ~w(
+    BITCOUNT BITFIELD_RO BITPOS DBSIZE DUMP EVAL_RO EVALSHA_RO EXISTS EXPIRETIME
+    FCALL_RO
+    GEODIST GEOHASH GEOPOS GEOSEARCH
+    GET GETBIT GETRANGE
+    HGET HGETALL HEXISTS HKEYS HLEN HMGET HRANDFIELD HSCAN HSTRLEN HVALS
+    KEYS LCS LINDEX LLEN LPOS LRANGE
+    MGET OBJECT PEXPIRETIME PFCOUNT PTTL RANDOMKEY SCAN SORT_RO
+    SCARD SDIFF SINTER SINTERCARD SISMEMBER SMEMBERS SMISMEMBER SRANDMEMBER SSCAN
+    STRLEN SUBSTR SUNION TTL TYPE
+    XINFO XLEN XPENDING XRANGE XREAD XREVRANGE
+    ZCARD ZCOUNT ZDIFF ZINTER ZINTERCARD ZLEXCOUNT ZMSCORE ZRANDMEMBER
+    ZRANGE ZRANGEBYLEX ZRANGEBYSCORE ZRANK ZREVRANGE ZREVRANGEBYLEX
+    ZREVRANGEBYSCORE ZREVRANK ZSCAN ZSCORE ZUNION
+  )
+
+  @spec fetch(GenServer.server(), [String.t()], timeout()) :: MapSet.t(String.t())
+  def fetch(connection, extra_commands \\ [], timeout \\ 5_000) do
+    discovered =
+      case Connection.command(connection, ["COMMAND"], timeout: timeout) do
+        {:ok, response} -> from_command_response(response)
+        {:error, _reason} -> MapSet.new()
+      end
+
+    @fallback_read_only
+    |> MapSet.new()
+    |> MapSet.union(discovered)
+    |> MapSet.union(normalize_commands(extra_commands))
+  end
+
+  @doc false
+  @spec from_command_response(term()) :: MapSet.t(String.t())
+  def from_command_response(response), do: collect(response, MapSet.new())
+
+  @spec read_only?(MapSet.t(String.t()), [term()]) :: boolean()
+  def read_only?(_commands, []), do: false
+
+  def read_only?(commands, [command | arguments]) do
+    command = command |> to_string() |> String.upcase()
+
+    subcommand =
+      case arguments do
+        [subcommand | _rest] -> command <> "|" <> (subcommand |> to_string() |> String.upcase())
+        [] -> nil
+      end
+
+    MapSet.member?(commands, command) or
+      (subcommand != nil and MapSet.member?(commands, subcommand))
+  end
+
+  defp collect([name, arity, flags | rest], commands)
+       when is_binary(name) and is_integer(arity) do
+    commands =
+      if flag_member?(flags, "readonly") do
+        MapSet.put(commands, String.upcase(name))
+      else
+        commands
+      end
+
+    Enum.reduce(rest, commands, &collect/2)
+  end
+
+  defp collect(list, commands) when is_list(list),
+    do: Enum.reduce(list, commands, &collect/2)
+
+  defp collect(_term, commands), do: commands
+
+  defp flag_member?(%MapSet{} = flags, flag), do: MapSet.member?(flags, flag)
+  defp flag_member?(flags, flag) when is_list(flags), do: flag in flags
+  defp flag_member?(_flags, _flag), do: false
+
+  defp normalize_commands(commands) do
+    commands
+    |> List.wrap()
+    |> Enum.map(&(to_string(&1) |> String.upcase()))
+    |> MapSet.new()
+  end
+end

--- a/lib/redis/replica_set/topology.ex
+++ b/lib/redis/replica_set/topology.ex
@@ -1,0 +1,119 @@
+defmodule Redis.ReplicaSet.Topology do
+  @moduledoc false
+
+  alias Redis.Connection
+
+  @type node_address :: {String.t(), non_neg_integer()}
+
+  @spec discover(GenServer.server(), timeout()) ::
+          {:ok, [node_address()]} | {:error, term()}
+  def discover(primary, timeout \\ 5_000) do
+    case Connection.command(primary, ["INFO", "REPLICATION"], timeout: timeout) do
+      {:ok, info} when is_binary(info) -> parse_info(info)
+      {:ok, _unexpected} -> {:error, :invalid_replication_info}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  @doc false
+  @spec parse_info(binary()) :: {:ok, [node_address()]} | {:error, term()}
+  def parse_info(info) when is_binary(info) do
+    fields =
+      info
+      |> String.split(~r/\r?\n/, trim: true)
+      |> Enum.reject(&String.starts_with?(&1, "#"))
+
+    if Enum.any?(fields, &(&1 in ["role:master", "role:primary"])) do
+      replicas =
+        fields
+        |> Enum.flat_map(&parse_replica_line/1)
+        |> Enum.uniq()
+
+      {:ok, replicas}
+    else
+      {:error, :not_primary}
+    end
+  end
+
+  def parse_info(_info), do: {:error, :invalid_replication_info}
+
+  @doc false
+  @spec parse_sentinel_replicas(term()) :: [node_address()]
+  def parse_sentinel_replicas(replicas) when is_list(replicas) do
+    replicas
+    |> Enum.flat_map(fn replica ->
+      replica
+      |> flat_list_to_map()
+      |> sentinel_replica_address()
+    end)
+    |> Enum.uniq()
+  end
+
+  def parse_sentinel_replicas(_replicas), do: []
+
+  defp parse_replica_line(line) do
+    case String.split(line, ":", parts: 2) do
+      [label, attributes] ->
+        if String.match?(label, ~r/\A(?:slave|replica)\d+\z/) do
+          attributes
+          |> parse_attributes(",")
+          |> info_replica_address()
+        else
+          []
+        end
+
+      _ ->
+        []
+    end
+  end
+
+  defp info_replica_address(%{"ip" => host, "port" => port, "state" => "online"}) do
+    address(host, port)
+  end
+
+  defp info_replica_address(_attributes), do: []
+
+  defp sentinel_replica_address(attributes) do
+    flags = attributes |> Map.get("flags", "") |> String.split(",")
+    link_status = Map.get(attributes, "master-link-status")
+    unavailable_flags = ["s_down", "o_down", "disconnected"]
+
+    if Enum.any?(flags, &(&1 in unavailable_flags)) or link_status not in [nil, "ok"] do
+      []
+    else
+      address(Map.get(attributes, "ip"), Map.get(attributes, "port"))
+    end
+  end
+
+  defp address(host, port) when is_binary(host) and host != "" and is_binary(port) do
+    case Integer.parse(port) do
+      {port, ""} when port in 1..65_535 -> [{host, port}]
+      _ -> []
+    end
+  end
+
+  defp address(_host, _port), do: []
+
+  defp parse_attributes(data, separator) do
+    data
+    |> String.split(separator)
+    |> Enum.reduce(%{}, fn field, attributes ->
+      case String.split(field, "=", parts: 2) do
+        [key, value] -> Map.put(attributes, key, value)
+        _ -> attributes
+      end
+    end)
+  end
+
+  defp flat_list_to_map(list) when is_list(list) do
+    list
+    |> Enum.chunk_every(2)
+    |> Map.new(fn
+      [key, value] -> {key, value}
+      [key] -> {key, nil}
+    end)
+  end
+
+  defp flat_list_to_map(map) when is_map(map), do: map
+  defp flat_list_to_map(_list), do: %{}
+end

--- a/lib/redis/sentinel/monitor.ex
+++ b/lib/redis/sentinel/monitor.ex
@@ -30,6 +30,7 @@ defmodule Redis.Sentinel.Monitor do
     :sentinel_host,
     :sentinel_port,
     :sentinel_password,
+    :sentinel_username,
     :group,
     :notify,
     :socket,
@@ -53,6 +54,7 @@ defmodule Redis.Sentinel.Monitor do
       sentinel_host: Keyword.fetch!(opts, :sentinel_host),
       sentinel_port: Keyword.fetch!(opts, :sentinel_port),
       sentinel_password: Keyword.get(opts, :sentinel_password),
+      sentinel_username: Keyword.get(opts, :sentinel_username),
       group: Keyword.fetch!(opts, :group),
       notify: Keyword.fetch!(opts, :notify),
       timeout: Keyword.get(opts, :timeout, 5_000)
@@ -122,7 +124,13 @@ defmodule Redis.Sentinel.Monitor do
   defp maybe_auth(_socket, %{sentinel_password: nil}), do: :ok
 
   defp maybe_auth(socket, state) do
-    :gen_tcp.send(socket, RESP2.encode(["AUTH", state.sentinel_password]))
+    arguments =
+      case state.sentinel_username do
+        nil -> ["AUTH", state.sentinel_password]
+        username -> ["AUTH", username, state.sentinel_password]
+      end
+
+    :gen_tcp.send(socket, RESP2.encode(arguments))
 
     case :gen_tcp.recv(socket, 0, state.timeout) do
       {:ok, data} ->

--- a/lib/redis/sentinel/sentinel.ex
+++ b/lib/redis/sentinel/sentinel.ex
@@ -6,6 +6,16 @@ defmodule Redis.Sentinel do
   maintains a connection. On disconnection, re-queries sentinels to
   find the (possibly new) primary.
 
+  With `:read_preference`, the client maintains primary and replica
+  connections, routes eligible reads to replicas, and keeps writes and
+  transactions on the primary:
+
+      {:ok, conn} = Redis.Sentinel.start_link(
+        sentinels: [{"sentinel1", 26379}, {"sentinel2", 26379}],
+        group: "mymaster",
+        read_preference: :prefer_replica
+      )
+
   ## Usage
 
       {:ok, conn} = Redis.Sentinel.start_link(
@@ -23,12 +33,18 @@ defmodule Redis.Sentinel do
     * `:sentinels` - list of sentinel addresses as `{host, port}` tuples or `"host:port"` strings (required)
     * `:group` - sentinel group name (required)
     * `:role` - `:primary` or `:replica` (default: `:primary`)
+    * `:read_preference` - `:master` (default), `:replica`, or
+      `:prefer_replica`. Cannot be combined with `role: :replica`.
+    * `:read_only_commands` - extra command names that are safe to run on replicas
     * `:password` - password for the Redis server (not the sentinel)
     * `:sentinel_password` - password for sentinel connections
+    * `:sentinel_username` - username for sentinel connections
     * `:username` - username for the Redis server
     * `:database` - database number
     * `:timeout` - connection timeout ms (default: 5_000)
     * `:sentinel_timeout` - sentinel query timeout ms (default: 500)
+    * `:topology_refresh_interval` - Sentinel topology refresh interval in
+      milliseconds for replica routing (default: 30_000; `nil` disables it)
     * `:name` - GenServer name registration
     * `:protocol` - `:resp3` or `:resp2` (default: `:resp3`)
   """
@@ -37,6 +53,8 @@ defmodule Redis.Sentinel do
 
   alias Redis.Connection
   alias Redis.Protocol.RESP2
+  alias Redis.ReplicaSet
+  alias Redis.ReplicaSet.Topology
   alias Redis.Sentinel.Monitor
 
   require Logger
@@ -47,6 +65,7 @@ defmodule Redis.Sentinel do
     :role,
     :password,
     :sentinel_password,
+    :sentinel_username,
     :username,
     :database,
     :timeout,
@@ -54,6 +73,11 @@ defmodule Redis.Sentinel do
     :protocol,
     :conn,
     :current_addr,
+    :read_preference,
+    :read_only_commands,
+    :replica_set,
+    :topology_refresh_interval,
+    replica_addrs: [],
     backoff_initial: 500,
     backoff_max: 30_000,
     backoff_current: 500,
@@ -97,6 +121,10 @@ defmodule Redis.Sentinel do
   @spec info(GenServer.server()) :: map()
   def info(sentinel), do: GenServer.call(sentinel, :info)
 
+  @doc "Refreshes primary and replica topology from Sentinel."
+  @spec refresh(GenServer.server()) :: :ok | {:error, term()}
+  def refresh(sentinel), do: GenServer.call(sentinel, :refresh, 30_000)
+
   @spec stop(GenServer.server()) :: :ok
   def stop(sentinel), do: GenServer.stop(sentinel, :normal)
 
@@ -115,19 +143,40 @@ defmodule Redis.Sentinel do
       sentinels: sentinels,
       group: group,
       role: Keyword.get(opts, :role, :primary),
+      read_preference: Keyword.get(opts, :read_preference, :master),
+      read_only_commands: Keyword.get(opts, :read_only_commands, []),
       password: Keyword.get(opts, :password),
       sentinel_password: Keyword.get(opts, :sentinel_password),
+      sentinel_username: Keyword.get(opts, :sentinel_username),
       username: Keyword.get(opts, :username),
       database: Keyword.get(opts, :database),
       timeout: Keyword.get(opts, :timeout, 5_000),
       sentinel_timeout: Keyword.get(opts, :sentinel_timeout, 500),
-      protocol: Keyword.get(opts, :protocol, :resp3)
+      topology_refresh_interval: Keyword.get(opts, :topology_refresh_interval, 30_000),
+      protocol: Keyword.get(opts, :protocol, :resp3),
+      backoff_initial: Keyword.get(opts, :backoff_initial, 500),
+      backoff_max: Keyword.get(opts, :backoff_max, 30_000),
+      backoff_current: Keyword.get(opts, :backoff_initial, 500)
     }
 
-    case resolve_and_connect(state) do
+    case validate_routing_options(state) do
+      :ok -> initialize_connection(state)
+      {:error, reason} -> {:stop, reason}
+    end
+  end
+
+  defp initialize_connection(state) do
+    connect_result =
+      if replica_routing?(state) do
+        resolve_and_start_replica_set(state)
+      else
+        resolve_and_connect(state)
+      end
+
+    case connect_result do
       {:ok, state} ->
         # Start failover monitor on the first reachable sentinel
-        state = start_monitor(state)
+        state = state |> start_monitor() |> schedule_topology_refresh()
         {:ok, state}
 
       {:error, reason} ->
@@ -143,6 +192,7 @@ defmodule Redis.Sentinel do
                sentinel_host: host,
                sentinel_port: port,
                sentinel_password: state.sentinel_password,
+               sentinel_username: state.sentinel_username,
                group: state.group,
                notify: self()
              ) do
@@ -155,6 +205,11 @@ defmodule Redis.Sentinel do
   end
 
   @impl true
+  def handle_call({:command, args}, _from, %{replica_set: replica_set} = state)
+      when replica_set != nil do
+    {:reply, ReplicaSet.command(replica_set, args, timeout: state.timeout), state}
+  end
+
   def handle_call({:command, args}, _from, %{conn: conn} = state) when conn != nil do
     case Connection.command(conn, args) do
       {:error, %Redis.ConnectionError{}} = error ->
@@ -172,8 +227,18 @@ defmodule Redis.Sentinel do
     end
   end
 
+  def handle_call({:pipeline, commands}, _from, %{replica_set: replica_set} = state)
+      when replica_set != nil do
+    {:reply, ReplicaSet.pipeline(replica_set, commands, timeout: state.timeout), state}
+  end
+
   def handle_call({:pipeline, commands}, _from, %{conn: conn} = state) when conn != nil do
     {:reply, Connection.pipeline(conn, commands), state}
+  end
+
+  def handle_call({:transaction, commands}, _from, %{replica_set: replica_set} = state)
+      when replica_set != nil do
+    {:reply, ReplicaSet.transaction(replica_set, commands, timeout: state.timeout), state}
   end
 
   def handle_call({:transaction, commands}, _from, %{conn: conn} = state) when conn != nil do
@@ -181,15 +246,31 @@ defmodule Redis.Sentinel do
   end
 
   def handle_call(:info, _from, state) do
+    replica_info = replica_set_info(state.replica_set)
+
     info = %{
       group: state.group,
       role: state.role,
+      read_preference: state.read_preference,
       current_addr: state.current_addr,
+      replica_addrs: Map.get(replica_info, :replicas, state.replica_addrs),
+      connected_replicas: Map.get(replica_info, :connected_replicas, []),
       sentinels: state.sentinels,
-      connected: state.conn != nil
+      connected: state.conn != nil or state.replica_set != nil
     }
 
     {:reply, info, state}
+  end
+
+  def handle_call(:refresh, _from, state) do
+    if replica_routing?(state) do
+      case resolve_or_refresh_replica_set(state) do
+        {:ok, state} -> {:reply, :ok, state}
+        {:error, reason} -> {:reply, {:error, reason}, state}
+      end
+    else
+      {:reply, :ok, state}
+    end
   end
 
   def handle_call(_msg, _from, %{conn: nil} = state) do
@@ -197,6 +278,16 @@ defmodule Redis.Sentinel do
   end
 
   @impl true
+  def handle_info({:EXIT, pid, reason}, %{replica_set: pid} = state) when reason != :normal do
+    Logger.warning("Redis.Sentinel: replica-set router exited, re-resolving via sentinels")
+    state = %{state | replica_set: nil, current_addr: nil, replica_addrs: []}
+
+    case resolve_and_start_replica_set(state) do
+      {:ok, state} -> {:noreply, state}
+      {:error, _reason} -> {:noreply, schedule_reconnect(state)}
+    end
+  end
+
   def handle_info({:EXIT, pid, reason}, %{conn: pid} = state) when reason != :normal do
     Logger.warning("Redis.Sentinel: connection lost, re-resolving via sentinels")
     state = %{state | conn: nil, current_addr: nil}
@@ -210,9 +301,67 @@ defmodule Redis.Sentinel do
   def handle_info({:EXIT, _pid, _reason}, state), do: {:noreply, state}
 
   def handle_info(:reconnect, state) do
-    case resolve_and_connect(state) do
+    result =
+      if replica_routing?(state) do
+        resolve_or_refresh_replica_set(state)
+      else
+        resolve_and_connect(state)
+      end
+
+    case result do
       {:ok, state} -> {:noreply, state}
       {:error, _} -> {:noreply, schedule_reconnect(state)}
+    end
+  end
+
+  def handle_info(
+        {:failover, group, _new_host, _new_port},
+        %{
+          group: group,
+          replica_set: replica_set
+        } = state
+      )
+      when replica_set != nil do
+    send(self(), :refresh_sentinel_topology)
+    {:noreply, state}
+  end
+
+  def handle_info(:refresh_sentinel_topology, state) do
+    case resolve_or_refresh_replica_set(state) do
+      {:ok, state} ->
+        {:noreply, state}
+
+      {:error, reason} ->
+        Logger.warning("Redis.Sentinel: topology refresh failed: #{inspect(reason)}")
+        Process.send_after(self(), :refresh_sentinel_topology, state.backoff_current)
+        {:noreply, increase_backoff(state)}
+    end
+  end
+
+  def handle_info(:refresh_replica_topology, state) do
+    state =
+      case resolve_or_refresh_replica_set(state) do
+        {:ok, state} ->
+          state
+
+        {:error, reason} ->
+          Logger.warning("Redis.Sentinel: periodic topology refresh failed: #{inspect(reason)}")
+          state
+      end
+
+    {:noreply, schedule_topology_refresh(state)}
+  end
+
+  def handle_info(
+        {:failover, group, _new_host, _new_port},
+        %{group: group, role: :replica} = state
+      ) do
+    state = reconnect(state)
+
+    if state.conn do
+      {:noreply, state}
+    else
+      {:noreply, schedule_reconnect(state)}
     end
   end
 
@@ -269,11 +418,123 @@ defmodule Redis.Sentinel do
         :exit, _ -> :ok
       end
     end
+
+    if state.replica_set do
+      try do
+        ReplicaSet.stop(state.replica_set)
+      catch
+        :exit, _ -> :ok
+      end
+    end
   end
 
   # -------------------------------------------------------------------
   # Sentinel resolution
   # -------------------------------------------------------------------
+
+  defp resolve_and_start_replica_set(state) do
+    with {:ok, primary, replicas} <- resolve_topology(state),
+         {:ok, replica_set} <- ReplicaSet.start_link(replica_set_opts(state, primary, replicas)) do
+      Logger.debug(
+        "Redis.Sentinel: connected to primary #{format_address(primary)} " <>
+          "with #{length(replicas)} replica(s)"
+      )
+
+      {:ok,
+       %{
+         state
+         | replica_set: replica_set,
+           current_addr: primary,
+           replica_addrs: replicas,
+           backoff_current: state.backoff_initial
+       }}
+    end
+  end
+
+  defp resolve_or_refresh_replica_set(%{replica_set: nil} = state),
+    do: resolve_and_start_replica_set(state)
+
+  defp resolve_or_refresh_replica_set(state) do
+    with {:ok, primary, replicas} <- resolve_topology(state),
+         :ok <- ReplicaSet.update_topology(state.replica_set, primary, replicas) do
+      {:ok,
+       %{
+         state
+         | current_addr: primary,
+           replica_addrs: replicas,
+           backoff_current: state.backoff_initial
+       }}
+    end
+  end
+
+  defp resolve_topology(state) do
+    Enum.find_value(state.sentinels, {:error, :no_reachable_sentinel}, fn {host, port} ->
+      case query_sentinel_topology(host, port, state) do
+        {:ok, _primary, _replicas} = topology -> topology
+        {:error, _reason} -> nil
+      end
+    end)
+  end
+
+  defp query_sentinel_topology(host, port, state) do
+    opts =
+      [
+        host: host,
+        port: port,
+        protocol: :resp2,
+        timeout: state.sentinel_timeout,
+        exit_on_disconnection: true
+      ]
+      |> maybe_put(:password, state.sentinel_password)
+      |> maybe_put(:username, state.sentinel_username)
+
+    case Connection.start_link(opts) do
+      {:ok, sentinel} ->
+        result = fetch_sentinel_topology(sentinel, state)
+        stop_connection(sentinel)
+        result
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp fetch_sentinel_topology(sentinel, state) do
+    with {:ok, [primary_host, primary_port]} <-
+           Connection.command(
+             sentinel,
+             ["SENTINEL", "GET-MASTER-ADDR-BY-NAME", state.group],
+             timeout: state.sentinel_timeout
+           ),
+         {:ok, primary_port} <- parse_port(primary_port),
+         {:ok, replicas} <-
+           Connection.command(
+             sentinel,
+             ["SENTINEL", "REPLICAS", state.group],
+             timeout: state.sentinel_timeout
+           ) do
+      {:ok, {primary_host, primary_port}, Topology.parse_sentinel_replicas(replicas)}
+    else
+      {:ok, nil} -> {:error, {:unknown_group, state.group}}
+      {:error, reason} -> {:error, reason}
+      _unexpected -> {:error, :sentinel_query_failed}
+    end
+  end
+
+  defp replica_set_opts(state, primary, replicas) do
+    [
+      primary: primary,
+      replicas: replicas,
+      read_preference: state.read_preference,
+      read_only_commands: state.read_only_commands,
+      topology_refresh_interval: nil,
+      protocol: state.protocol,
+      timeout: state.timeout
+    ]
+    |> maybe_put(:password, state.password)
+    |> maybe_put(:username, state.username)
+    |> maybe_put(:database, state.database)
+  end
 
   defp resolve_and_connect(state) do
     with {:ok, host, port} <- resolve_address(state),
@@ -335,10 +596,16 @@ defmodule Redis.Sentinel do
 
   defp maybe_auth_sentinel(_socket, %{sentinel_password: nil}), do: :ok
 
-  defp maybe_auth_sentinel(socket, %{sentinel_password: pw, sentinel_timeout: timeout}) do
-    :gen_tcp.send(socket, RESP2.encode(["AUTH", pw]))
+  defp maybe_auth_sentinel(socket, state) do
+    arguments =
+      case state.sentinel_username do
+        nil -> ["AUTH", state.sentinel_password]
+        username -> ["AUTH", username, state.sentinel_password]
+      end
 
-    case :gen_tcp.recv(socket, 0, timeout) do
+    :gen_tcp.send(socket, RESP2.encode(arguments))
+
+    case :gen_tcp.recv(socket, 0, state.sentinel_timeout) do
       {:ok, data} ->
         case RESP2.decode(data) do
           {:ok, "OK", _} -> :ok
@@ -440,12 +707,68 @@ defmodule Redis.Sentinel do
 
   defp schedule_reconnect(state) do
     Process.send_after(self(), :reconnect, state.backoff_current)
-    %{state | backoff_current: min(state.backoff_current * 2, state.backoff_max)}
+    increase_backoff(state)
   end
 
   # -------------------------------------------------------------------
   # Helpers
   # -------------------------------------------------------------------
+
+  defp validate_routing_options(%{role: role}) when role not in [:primary, :replica],
+    do: {:error, {:invalid_role, role}}
+
+  defp validate_routing_options(%{read_preference: preference})
+       when preference not in [:master, :replica, :prefer_replica],
+       do: {:error, {:invalid_read_preference, preference}}
+
+  defp validate_routing_options(%{role: :replica, read_preference: preference})
+       when preference != :master,
+       do: {:error, :replica_role_conflicts_with_read_preference}
+
+  defp validate_routing_options(_state), do: :ok
+
+  defp replica_routing?(state),
+    do: state.read_preference in [:replica, :prefer_replica]
+
+  defp replica_set_info(nil), do: %{}
+
+  defp replica_set_info(replica_set) do
+    ReplicaSet.info(replica_set)
+  catch
+    :exit, _reason -> %{}
+  end
+
+  defp increase_backoff(state) do
+    %{state | backoff_current: min(state.backoff_current * 2, state.backoff_max)}
+  end
+
+  defp schedule_topology_refresh(state) do
+    if replica_routing?(state) and is_integer(state.topology_refresh_interval) and
+         state.topology_refresh_interval > 0 do
+      Process.send_after(self(), :refresh_replica_topology, state.topology_refresh_interval)
+    end
+
+    state
+  end
+
+  defp parse_port(port) when is_integer(port) and port in 1..65_535, do: {:ok, port}
+
+  defp parse_port(port) when is_binary(port) do
+    case Integer.parse(port) do
+      {port, ""} when port in 1..65_535 -> {:ok, port}
+      _ -> {:error, :invalid_port}
+    end
+  end
+
+  defp parse_port(_port), do: {:error, :invalid_port}
+
+  defp format_address({host, port}), do: "#{host}:#{port}"
+
+  defp stop_connection(connection) do
+    Connection.stop(connection)
+  catch
+    :exit, _reason -> :ok
+  end
 
   defp parse_sentinels(sentinels) do
     Enum.map(sentinels, fn

--- a/test/integration/replica_set_test.exs
+++ b/test/integration/replica_set_test.exs
@@ -1,0 +1,189 @@
+defmodule Redis.ReplicaSetTest do
+  use ExUnit.Case, async: false
+
+  alias Redis.Connection
+  alias Redis.ReplicaSet
+
+  @primary_port 6472
+  @replica_port 6473
+
+  setup_all do
+    {:ok, primary} =
+      RedisServerWrapper.Server.start_link(
+        port: @primary_port,
+        extra: [{"repl-diskless-sync-delay", "0"}]
+      )
+
+    {:ok, replica} =
+      RedisServerWrapper.Server.start_link(
+        port: @replica_port,
+        replicaof: {"127.0.0.1", @primary_port}
+      )
+
+    {:ok, primary_connection} = Connection.start_link(port: @primary_port)
+    {:ok, replica_connection} = Connection.start_link(port: @replica_port)
+
+    eventually(
+      fn ->
+        with {:ok, primary_info} <-
+               Connection.command(primary_connection, ["INFO", "REPLICATION"]),
+             {:ok, replica_info} <-
+               Connection.command(replica_connection, ["INFO", "REPLICATION"]) do
+          String.contains?(primary_info, "state=online") and
+            String.contains?(replica_info, "master_link_status:up")
+        else
+          _error -> false
+        end
+      end,
+      200
+    )
+
+    Connection.stop(primary_connection)
+    Connection.stop(replica_connection)
+
+    on_exit(fn ->
+      stop_server(replica)
+      stop_server(primary)
+    end)
+
+    :ok
+  end
+
+  test "discovers replicas with INFO and routes reads to them" do
+    {:ok, redis} =
+      ReplicaSet.start_link(
+        primary: {"127.0.0.1", @primary_port},
+        read_preference: :replica,
+        read_only_commands: ["ROLE"],
+        topology_refresh_interval: nil
+      )
+
+    assert %{
+             primary: {"127.0.0.1", @primary_port},
+             replicas: replicas,
+             connected_replicas: connected,
+             discovery: :info
+           } = ReplicaSet.info(redis)
+
+    assert {"127.0.0.1", @replica_port} in replicas
+    assert {"127.0.0.1", @replica_port} in connected
+    assert {:ok, [role | _]} = ReplicaSet.command(redis, ["ROLE"])
+    assert role in ["slave", "replica"]
+
+    ReplicaSet.stop(redis)
+  end
+
+  test "keeps writes and mixed pipelines on the primary" do
+    {:ok, redis} =
+      ReplicaSet.start_link(
+        primary: {"127.0.0.1", @primary_port},
+        replicas: [{"127.0.0.1", @replica_port}],
+        read_preference: :replica,
+        read_only_commands: ["ROLE"]
+      )
+
+    key = "replica-set:#{System.unique_integer([:positive])}"
+    assert {:ok, "OK"} = ReplicaSet.command(redis, ["SET", key, "value"])
+    eventually(fn -> ReplicaSet.command(redis, ["GET", key]) == {:ok, "value"} end)
+
+    assert {:ok, ["OK", [role | _]]} =
+             ReplicaSet.pipeline(redis, [
+               ["SET", key, "updated"],
+               ["ROLE"]
+             ])
+
+    assert role in ["master", "primary"]
+    ReplicaSet.stop(redis)
+  end
+
+  test "routes all-read pipelines to a replica" do
+    {:ok, redis} =
+      ReplicaSet.start_link(
+        primary: {"127.0.0.1", @primary_port},
+        replicas: [{"127.0.0.1", @replica_port}],
+        read_preference: :prefer_replica,
+        read_only_commands: ["ROLE"]
+      )
+
+    assert {:ok, [[role | _]]} = ReplicaSet.pipeline(redis, [["ROLE"]])
+    assert role in ["slave", "replica"]
+    ReplicaSet.stop(redis)
+  end
+
+  test "master preference and missing replicas use the primary" do
+    {:ok, master_only} =
+      ReplicaSet.start_link(
+        primary: {"127.0.0.1", @primary_port},
+        replicas: [{"127.0.0.1", @replica_port}],
+        read_preference: :master,
+        read_only_commands: ["ROLE"]
+      )
+
+    assert {:ok, [master_role | _]} = ReplicaSet.command(master_only, ["ROLE"])
+    assert master_role in ["master", "primary"]
+    ReplicaSet.stop(master_only)
+
+    {:ok, fallback} =
+      ReplicaSet.start_link(
+        primary: {"127.0.0.1", 6398},
+        replicas: [],
+        read_preference: :replica,
+        read_only_commands: ["ROLE"]
+      )
+
+    assert {:ok, [fallback_role | _]} = ReplicaSet.command(fallback, ["ROLE"])
+    assert fallback_role in ["master", "primary"]
+    ReplicaSet.stop(fallback)
+  end
+
+  test "updates topology without restarting the router" do
+    {:ok, redis} =
+      ReplicaSet.start_link(
+        primary: {"127.0.0.1", @primary_port},
+        replicas: [],
+        read_preference: :replica,
+        read_only_commands: ["ROLE"]
+      )
+
+    assert :ok =
+             ReplicaSet.update_topology(
+               redis,
+               {"127.0.0.1", @primary_port},
+               [{"127.0.0.1", @replica_port}]
+             )
+
+    assert {:ok, [role | _]} = ReplicaSet.command(redis, ["ROLE"])
+    assert role in ["slave", "replica"]
+    ReplicaSet.stop(redis)
+  end
+
+  test "rejects invalid read preferences" do
+    Process.flag(:trap_exit, true)
+
+    assert {:error, {:invalid_read_preference, :nearest}} =
+             ReplicaSet.start_link(
+               primary: {"127.0.0.1", @primary_port},
+               read_preference: :nearest
+             )
+  end
+
+  defp eventually(predicate, attempts \\ 100)
+  defp eventually(_predicate, 0), do: flunk("condition did not become true")
+
+  defp eventually(predicate, attempts) do
+    if predicate.() do
+      :ok
+    else
+      Process.sleep(20)
+      eventually(predicate, attempts - 1)
+    end
+  end
+
+  defp stop_server(server) do
+    if Process.alive?(server) do
+      RedisServerWrapper.Server.stop(server)
+    end
+  catch
+    :exit, _reason -> :ok
+  end
+end

--- a/test/integration/sentinel_test.exs
+++ b/test/integration/sentinel_test.exs
@@ -98,5 +98,58 @@ defmodule Redis.SentinelTest do
 
       Sentinel.stop(conn)
     end
+
+    test "routes eligible reads to replicas and writes to the primary" do
+      {:ok, conn} =
+        Sentinel.start_link(
+          sentinels: [{"127.0.0.1", 26_400}, {"127.0.0.1", 26_401}],
+          group: "mymaster",
+          read_preference: :replica,
+          read_only_commands: ["ROLE"],
+          topology_refresh_interval: nil
+        )
+
+      eventually(fn ->
+        Sentinel.refresh(conn) == :ok and Sentinel.info(conn).connected_replicas != []
+      end)
+
+      assert {:ok, [replica_role | _]} = Sentinel.command(conn, ["ROLE"])
+      assert replica_role in ["slave", "replica"]
+
+      key = "sentinel:replica-routing:#{System.unique_integer([:positive])}"
+      assert {:ok, "OK"} = Sentinel.command(conn, ["SET", key, "value"])
+      eventually(fn -> Sentinel.command(conn, ["GET", key]) == {:ok, "value"} end)
+
+      info = Sentinel.info(conn)
+      assert info.read_preference == :replica
+      assert {"127.0.0.1", 6501} in info.replica_addrs
+      assert {"127.0.0.1", 6501} in info.connected_replicas
+
+      Sentinel.stop(conn)
+    end
+
+    test "rejects a fixed replica role combined with read preference routing" do
+      Process.flag(:trap_exit, true)
+
+      assert {:error, :replica_role_conflicts_with_read_preference} =
+               Sentinel.start_link(
+                 sentinels: [{"127.0.0.1", 26_400}],
+                 group: "mymaster",
+                 role: :replica,
+                 read_preference: :prefer_replica
+               )
+    end
+  end
+
+  defp eventually(predicate, attempts \\ 200)
+  defp eventually(_predicate, 0), do: flunk("condition did not become true")
+
+  defp eventually(predicate, attempts) do
+    if predicate.() do
+      :ok
+    else
+      Process.sleep(50)
+      eventually(predicate, attempts - 1)
+    end
   end
 end

--- a/test/unit/replica_set/command_metadata_test.exs
+++ b/test/unit/replica_set/command_metadata_test.exs
@@ -1,0 +1,40 @@
+defmodule Redis.ReplicaSet.CommandMetadataTest do
+  use ExUnit.Case, async: true
+
+  alias Redis.ReplicaSet.CommandMetadata
+
+  test "extracts read-only commands and subcommands from COMMAND responses" do
+    response = [
+      ["get", 2, MapSet.new(["readonly", "fast"]), 1, 1, 1, [], [], [], []],
+      ["set", -3, MapSet.new(["write"]), 1, 1, 1, [], [], [], []],
+      [
+        "example",
+        -2,
+        MapSet.new(),
+        0,
+        0,
+        0,
+        [],
+        [],
+        [],
+        [
+          ["example|read", 2, ["readonly"], 0, 0, 0, [], [], [], []],
+          ["example|write", 2, ["write"], 0, 0, 0, [], [], [], []]
+        ]
+      ]
+    ]
+
+    commands = CommandMetadata.from_command_response(response)
+
+    assert CommandMetadata.read_only?(commands, ["GET", "key"])
+    assert CommandMetadata.read_only?(commands, ["EXAMPLE", "READ"])
+    refute CommandMetadata.read_only?(commands, ["SET", "key", "value"])
+    refute CommandMetadata.read_only?(commands, ["EXAMPLE", "WRITE"])
+    refute CommandMetadata.read_only?(commands, ["UNKNOWN", "key"])
+  end
+
+  test "ignores malformed command metadata" do
+    assert CommandMetadata.from_command_response([:invalid, ["missing", "arity"]]) ==
+             MapSet.new()
+  end
+end

--- a/test/unit/replica_set/topology_test.exs
+++ b/test/unit/replica_set/topology_test.exs
@@ -1,0 +1,68 @@
+defmodule Redis.ReplicaSet.TopologyTest do
+  use ExUnit.Case, async: true
+
+  alias Redis.ReplicaSet.Topology
+
+  describe "parse_info/1" do
+    test "extracts online replicas from primary INFO REPLICATION" do
+      info = """
+      # Replication
+      role:master
+      connected_slaves:3
+      slave0:ip=127.0.0.1,port=6380,state=online,offset=10,lag=0
+      slave1:ip=redis-two,port=6381,state=sync,offset=0,lag=1
+      replica2:ip=redis-three,port=6382,state=online,offset=10,lag=0
+      """
+
+      assert {:ok, replicas} = Topology.parse_info(info)
+      assert {"127.0.0.1", 6380} in replicas
+      assert {"redis-three", 6382} in replicas
+      refute {"redis-two", 6381} in replicas
+    end
+
+    test "rejects replication info from a replica" do
+      assert {:error, :not_primary} =
+               Topology.parse_info("role:slave\r\nmaster_host:127.0.0.1\r\n")
+    end
+
+    test "skips invalid addresses and unknown fields" do
+      info = """
+      role:master
+      future_field:value
+      slave0:ip=,port=6380,state=online
+      slave1:ip=host,port=invalid,state=online
+      """
+
+      assert {:ok, []} = Topology.parse_info(info)
+    end
+  end
+
+  describe "parse_sentinel_replicas/1" do
+    test "keeps only reachable replicas with healthy primary links" do
+      replicas = [
+        [
+          "ip",
+          "127.0.0.1",
+          "port",
+          "6380",
+          "flags",
+          "slave",
+          "master-link-status",
+          "ok"
+        ],
+        [
+          "ip",
+          "127.0.0.1",
+          "port",
+          "6381",
+          "flags",
+          "slave,s_down",
+          "master-link-status",
+          "down"
+        ]
+      ]
+
+      assert Topology.parse_sentinel_replicas(replicas) == [{"127.0.0.1", 6380}]
+    end
+  end
+end


### PR DESCRIPTION
Closes #114.

## What changed

- add `Redis.ReplicaSet` for manually configured primary/replica deployments
- discover online replicas from `INFO REPLICATION` when replica addresses are omitted
- derive read-only commands from Redis `COMMAND` metadata, with a conservative fallback and explicit extension option
- support `:master`, `:replica`, and `:prefer_replica` read preferences with round-robin replica selection
- keep writes, unknown commands, mixed pipelines, and transactions on the primary
- verify primary/replica roles and reconnect failed node connections
- add live topology updates so Sentinel can replace a promoted primary without restarting the client
- extend `Redis.Sentinel` with replica-aware routing, periodic/manual topology refresh, and Sentinel ACL usernames while preserving fixed `role` behavior
- document manual and Sentinel-managed read routing

## Semantics

- `:master` sends all traffic to the primary
- `:replica` sends eligible reads to replicas; it uses the primary only when no replica is available, but preserves runtime replica errors when configured replicas fail
- `:prefer_replica` additionally falls back to the primary after replica execution failures

## Validation

- `mix compile --force --warnings-as-errors`
- `mix format --check-formatted`
- `mix credo --strict`
- `mix dialyzer`
- `mix docs`
- downstream dependency compile with warnings as errors
- `UNIT_ONLY=true mix test test/unit/` (883 passed)
- live replica-set unit/integration suite (12 passed)
- `REDIS_SENTINEL=true mix test test/integration/sentinel_test.exs` (6 passed)
- `mix test` (1,173 passed)

BEGIN_COMMIT_OVERRIDE
feat: add primary/replica read routing
END_COMMIT_OVERRIDE
