### PR TITLE
Add opt-in typed Redis responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,29 @@ end)
 Watches keys, calls your function to read and compute commands, then
 executes in MULTI/EXEC. Automatically retries on conflict (default 3 attempts).
 
+## Typed Responses
+
+Raw RESP values remain the default. Opt into stable, protocol-independent
+values for commands with known reply shapes:
+
+```elixir
+{:ok, %{"name" => "Ada", "role" => "admin"}} =
+  Redis.command(conn, ["HGETALL", "user:1"], response: :typed)
+
+{:ok, [%Redis.Response.StreamEntry{id: id, fields: fields}]} =
+  Redis.command_typed(conn, ["XRANGE", "events", "-", "+"])
+
+{:ok, [hash, clients]} = Redis.pipeline_typed(conn, [
+  ["HGETALL", "user:1"],
+  ["CLIENT", "LIST"]
+])
+```
+
+Typed mode parses `HGETALL`, `CONFIG GET`, set operations, `INFO`,
+`CLIENT LIST`/`CLIENT INFO`, and the range/read stream commands. Unknown
+commands pass through unchanged, including within mixed pipelines. See
+`Redis.Response` for the complete return types.
+
 ## Command Builders
 
 Pure functions that return command lists. Use them with any connection type.

--- a/lib/redis.ex
+++ b/lib/redis.ex
@@ -12,6 +12,7 @@ defmodule Redis do
     * `Redis.Sentinel` - sentinel-aware client with failover
     * `Redis.PubSub` - pub/sub subscriptions
     * `Redis.Monitor` - structured real-time command monitoring
+    * `Redis.Response` - opt-in typed command responses
     * `Redis.PhoenixPubSub` - Phoenix.PubSub adapter
     * `Redis.Cache` - client-side caching with ETS
     * `Redis.Consumer` - streams consumer group GenServer
@@ -35,6 +36,14 @@ defmodule Redis do
         ["SET", "b", "2"],
         ["MGET", "a", "b"]
       ])
+
+  ## Typed Responses
+
+      {:ok, user} =
+        Redis.command(conn, ["HGETALL", "user:1"], response: :typed)
+
+      {:ok, entries} =
+        Redis.command_typed(conn, ["XRANGE", "events", "-", "+"])
 
   ## Transactions
 
@@ -68,6 +77,11 @@ defmodule Redis do
   @spec command(conn(), [String.t()], keyword()) :: {:ok, term()} | {:error, term()}
   def command(conn, args, opts \\ []), do: Connection.command(conn, args, opts)
 
+  @doc "Sends a single command with typed response parsing."
+  @spec command_typed(conn(), [String.t()], keyword()) :: {:ok, term()} | {:error, term()}
+  def command_typed(conn, args, opts \\ []),
+    do: Connection.command(conn, args, Keyword.put(opts, :response, :typed))
+
   @doc "Sends a single command, raises on error."
   @spec command!(conn(), [String.t()], keyword()) :: term()
   def command!(conn, args, opts \\ []) do
@@ -81,9 +95,21 @@ defmodule Redis do
   @spec pipeline(conn(), [[String.t()]], keyword()) :: {:ok, [term()]} | {:error, term()}
   def pipeline(conn, commands, opts \\ []), do: Connection.pipeline(conn, commands, opts)
 
+  @doc "Sends multiple commands with typed response parsing."
+  @spec pipeline_typed(conn(), [[String.t()]], keyword()) ::
+          {:ok, [term()]} | {:error, term()}
+  def pipeline_typed(conn, commands, opts \\ []),
+    do: Connection.pipeline(conn, commands, Keyword.put(opts, :response, :typed))
+
   @doc "Executes commands in a MULTI/EXEC transaction."
   @spec transaction(conn(), [[String.t()]], keyword()) :: {:ok, [term()]} | {:error, term()}
   def transaction(conn, commands, opts \\ []), do: Connection.transaction(conn, commands, opts)
+
+  @doc "Executes commands in a MULTI/EXEC transaction with typed response parsing."
+  @spec transaction_typed(conn(), [[String.t()]], keyword()) ::
+          {:ok, [term()]} | {:error, term()}
+  def transaction_typed(conn, commands, opts \\ []),
+    do: Connection.transaction(conn, commands, Keyword.put(opts, :response, :typed))
 
   @doc """
   Executes a WATCH-based optimistic locking transaction.

--- a/lib/redis/cluster/cluster.ex
+++ b/lib/redis/cluster/cluster.ex
@@ -22,12 +22,15 @@ defmodule Redis.Cluster do
     * `:name` - GenServer name registration
     * `:timeout` - command timeout ms (default: 5_000)
     * `:max_redirects` - max MOVED/ASK redirects before failing (default: 5)
+
+  Command, pipeline, and transaction calls accept `response: :typed`; see
+  `Redis.Response`.
   """
 
   use GenServer
 
   alias Redis.Cluster.{Router, Topology}
-  alias Redis.Connection
+  alias Redis.{Connection, Response}
 
   require Logger
 
@@ -57,7 +60,10 @@ defmodule Redis.Cluster do
           {:ok, term()} | {:error, term()}
   def command(cluster, args, opts \\ []) do
     timeout = Keyword.get(opts, :timeout, 10_000)
-    GenServer.call(cluster, {:command, args}, timeout)
+
+    cluster
+    |> GenServer.call({:command, args}, timeout)
+    |> Response.decode(args, opts)
   end
 
   @doc """
@@ -70,7 +76,10 @@ defmodule Redis.Cluster do
           {:ok, [term()]} | {:error, term()}
   def pipeline(cluster, commands, opts \\ []) do
     timeout = Keyword.get(opts, :timeout, 10_000)
-    GenServer.call(cluster, {:pipeline, commands}, timeout)
+
+    cluster
+    |> GenServer.call({:pipeline, commands}, timeout)
+    |> Response.decode_many(commands, opts)
   end
 
   @doc """
@@ -89,7 +98,10 @@ defmodule Redis.Cluster do
           {:ok, [term()]} | {:error, term()}
   def transaction(cluster, commands, opts \\ []) do
     timeout = Keyword.get(opts, :timeout, 10_000)
-    GenServer.call(cluster, {:transaction, commands}, timeout)
+
+    cluster
+    |> GenServer.call({:transaction, commands}, timeout)
+    |> Response.decode_many(commands, opts)
   end
 
   @doc """

--- a/lib/redis/connection/connection.ex
+++ b/lib/redis/connection/connection.ex
@@ -31,6 +31,10 @@ defmodule Redis.Connection do
     * `:hibernate_after` - idle ms before hibernation (default: nil)
     * `:hooks` - list of `Redis.Hook` modules for command middleware (default: [])
 
+  Command, pipeline, and transaction calls also accept `response: :typed` to
+  opt into the structured values documented by `Redis.Response`. Raw RESP
+  values remain the default.
+
   A Redis URI string may be passed as the first (sole) argument:
 
       Connection.start_link("redis://:secret@localhost:6380/2")
@@ -39,6 +43,7 @@ defmodule Redis.Connection do
   use GenServer
 
   alias Redis.Protocol.{RESP2, RESP3}
+  alias Redis.Response
 
   require Logger
 
@@ -114,7 +119,10 @@ defmodule Redis.Connection do
           {:ok, term()} | {:error, term()}
   def command(conn, args, opts \\ []) do
     timeout = Keyword.get(opts, :timeout, 5_000)
-    GenServer.call(conn, {:command, args}, timeout)
+
+    conn
+    |> GenServer.call({:command, args}, timeout)
+    |> Response.decode(args, opts)
   end
 
   @impl Redis.Connection.Behaviour
@@ -122,7 +130,10 @@ defmodule Redis.Connection do
           {:ok, [term()]} | {:error, term()}
   def pipeline(conn, commands, opts \\ []) do
     timeout = Keyword.get(opts, :timeout, 5_000)
-    GenServer.call(conn, {:pipeline, commands}, timeout)
+
+    conn
+    |> GenServer.call({:pipeline, commands}, timeout)
+    |> Response.decode_many(commands, opts)
   end
 
   @impl Redis.Connection.Behaviour
@@ -130,7 +141,10 @@ defmodule Redis.Connection do
           {:ok, [term()]} | {:error, term()}
   def transaction(conn, commands, opts \\ []) do
     timeout = Keyword.get(opts, :timeout, 5_000)
-    GenServer.call(conn, {:transaction, commands}, timeout)
+
+    conn
+    |> GenServer.call({:transaction, commands}, timeout)
+    |> Response.decode_many(commands, opts)
   end
 
   @doc """
@@ -191,7 +205,7 @@ defmodule Redis.Connection do
           do_watch_transaction(conn, keys, fun, opts, retries_left - 1)
 
         other ->
-          other
+          Response.decode_many(other, commands, opts)
       end
     else
       {:abort, reason} ->

--- a/lib/redis/error.ex
+++ b/lib/redis/error.ex
@@ -21,3 +21,30 @@ defmodule Redis.ConnectionError do
   def message(%{reason: reason}) when is_atom(reason), do: "connection error: #{reason}"
   def message(%{reason: reason}), do: "connection error: #{inspect(reason)}"
 end
+
+defmodule Redis.ResponseError do
+  @moduledoc """
+  Represents a failure while converting a raw Redis reply to a typed response.
+  """
+
+  defexception [:command, :reason, :response]
+
+  @type t :: %__MODULE__{
+          command: [term()] | nil,
+          reason: term(),
+          response: term()
+        }
+
+  @impl true
+  def message(%{command: command, reason: reason}) do
+    "could not parse response for #{format_command(command)}: #{format_reason(reason)}"
+  end
+
+  defp format_command([command | _]) when is_binary(command), do: String.upcase(command)
+  defp format_command(command), do: inspect(command)
+
+  defp format_reason({:invalid_response_mode, mode}),
+    do: "invalid response mode #{inspect(mode)} (expected :raw or :typed)"
+
+  defp format_reason(reason), do: inspect(reason)
+end

--- a/lib/redis/protocol/coerce.ex
+++ b/lib/redis/protocol/coerce.ex
@@ -15,7 +15,7 @@ defmodule Redis.Protocol.Coerce do
       #=> MapSet.new(["a", "b", "c"])
   """
 
-  @map_commands ~w(HGETALL CONFIG XRANGE XREVRANGE)
+  @map_commands ~w(HGETALL CONFIG)
   @set_commands ~w(SMEMBERS SDIFF SINTER SUNION)
 
   @doc """

--- a/lib/redis/replica_set.ex
+++ b/lib/redis/replica_set.ex
@@ -46,12 +46,16 @@ defmodule Redis.ReplicaSet do
   Normal `Redis.Connection` options such as authentication, TLS, protocol,
   database, credential provider, and timeout are shared by all nodes. A node
   expressed as a keyword list or URI may override shared options.
+
+  Command, pipeline, and transaction calls accept `response: :typed`; see
+  `Redis.Response`.
   """
 
   use GenServer
 
   alias Redis.Connection
   alias Redis.ReplicaSet.{CommandMetadata, Topology}
+  alias Redis.Response
 
   require Logger
 
@@ -114,21 +118,27 @@ defmodule Redis.ReplicaSet do
   @doc "Routes a command according to its mutability and the configured read preference."
   @spec command(GenServer.server(), [term()], keyword()) :: {:ok, term()} | {:error, term()}
   def command(replica_set, arguments, opts \\ []) do
-    GenServer.call(replica_set, {:command, arguments}, call_timeout(opts))
+    replica_set
+    |> GenServer.call({:command, arguments}, call_timeout(opts))
+    |> Response.decode(arguments, opts)
   end
 
   @doc "Routes an all-read pipeline to a replica and every other pipeline to the primary."
   @spec pipeline(GenServer.server(), [[term()]], keyword()) ::
           {:ok, [term()]} | {:error, term()}
   def pipeline(replica_set, commands, opts \\ []) do
-    GenServer.call(replica_set, {:pipeline, commands}, call_timeout(opts))
+    replica_set
+    |> GenServer.call({:pipeline, commands}, call_timeout(opts))
+    |> Response.decode_many(commands, opts)
   end
 
   @doc "Executes a transaction on the primary."
   @spec transaction(GenServer.server(), [[term()]], keyword()) ::
           {:ok, [term()]} | {:error, term()}
   def transaction(replica_set, commands, opts \\ []) do
-    GenServer.call(replica_set, {:transaction, commands}, call_timeout(opts))
+    replica_set
+    |> GenServer.call({:transaction, commands}, call_timeout(opts))
+    |> Response.decode_many(commands, opts)
   end
 
   @doc "Replaces the primary and replica addresses without restarting the router."

--- a/lib/redis/response.ex
+++ b/lib/redis/response.ex
@@ -1,0 +1,481 @@
+defmodule Redis.Response.Client do
+  @moduledoc """
+  A parsed record returned by `CLIENT LIST` or `CLIENT INFO`.
+
+  Fields mirror Redis' wire names where possible. `attributes` always contains
+  the complete raw key/value map so new server fields remain available before
+  this struct is updated.
+  """
+
+  @enforce_keys [:attributes]
+  defstruct [
+    :id,
+    :addr,
+    :laddr,
+    :fd,
+    :name,
+    :age,
+    :idle,
+    :db,
+    :sub,
+    :psub,
+    :ssub,
+    :multi,
+    :qbuf,
+    :qbuf_free,
+    :argv_mem,
+    :multi_mem,
+    :obl,
+    :oll,
+    :omem,
+    :tot_mem,
+    :events,
+    :cmd,
+    :user,
+    :redir,
+    :resp,
+    :lib_name,
+    :lib_ver,
+    :io_thread,
+    flags: MapSet.new(),
+    attributes: %{}
+  ]
+
+  @type t :: %__MODULE__{
+          id: integer() | nil,
+          addr: String.t() | nil,
+          laddr: String.t() | nil,
+          fd: integer() | nil,
+          name: String.t() | nil,
+          age: integer() | nil,
+          idle: integer() | nil,
+          flags: MapSet.t(String.t()),
+          db: integer() | nil,
+          sub: integer() | nil,
+          psub: integer() | nil,
+          ssub: integer() | nil,
+          multi: integer() | nil,
+          qbuf: integer() | nil,
+          qbuf_free: integer() | nil,
+          argv_mem: integer() | nil,
+          multi_mem: integer() | nil,
+          obl: integer() | nil,
+          oll: integer() | nil,
+          omem: integer() | nil,
+          tot_mem: integer() | nil,
+          events: String.t() | nil,
+          cmd: String.t() | nil,
+          user: String.t() | nil,
+          redir: integer() | nil,
+          resp: integer() | nil,
+          lib_name: String.t() | nil,
+          lib_ver: String.t() | nil,
+          io_thread: integer() | nil,
+          attributes: %{optional(String.t()) => String.t()}
+        }
+end
+
+defmodule Redis.Response.StreamEntry do
+  @moduledoc """
+  A Redis stream entry with its ID and field/value map.
+  """
+
+  @enforce_keys [:id, :fields]
+  defstruct [:id, :fields]
+
+  @type t :: %__MODULE__{
+          id: String.t(),
+          fields: %{optional(String.t()) => term()} | nil
+        }
+end
+
+defmodule Redis.Response.Stream do
+  @moduledoc """
+  A named stream and the entries returned by `XREAD` or `XREADGROUP`.
+  """
+
+  @enforce_keys [:name, :entries]
+  defstruct [:name, :entries]
+
+  @type t :: %__MODULE__{
+          name: String.t(),
+          entries: [Redis.Response.StreamEntry.t()]
+        }
+end
+
+defmodule Redis.Response do
+  @moduledoc """
+  Opt-in conversion of raw Redis replies into stable Elixir values.
+
+  Commands return raw RESP values by default. Pass `response: :typed` to
+  `Redis.command/3`, `Redis.pipeline/3`, or `Redis.transaction/3` to parse
+  replies whose shape is known:
+
+    * `HGETALL` and `CONFIG GET` return maps.
+    * `SMEMBERS`, `SDIFF`, `SINTER`, and `SUNION` return `MapSet`s.
+    * `INFO` returns a flat key/value map. Values remain strings.
+    * `CLIENT LIST` returns a list of `Redis.Response.Client` structs.
+    * `CLIENT INFO` returns one `Redis.Response.Client`.
+    * `XRANGE` and `XREVRANGE` return `Redis.Response.StreamEntry` structs.
+    * `XREAD` and `XREADGROUP` return `Redis.Response.Stream` structs.
+
+  Unsupported commands are returned unchanged. This makes typed mode safe for
+  mixed pipelines and preserves access to module-specific replies.
+  """
+
+  alias Redis.Response.{Client, Stream, StreamEntry}
+
+  @map_commands ~w(HGETALL)
+  @set_commands ~w(SMEMBERS SDIFF SINTER SUNION)
+  @range_commands ~w(XRANGE XREVRANGE)
+  @read_commands ~w(XREAD XREADGROUP)
+
+  @integer_client_fields %{
+    "id" => :id,
+    "fd" => :fd,
+    "age" => :age,
+    "idle" => :idle,
+    "db" => :db,
+    "sub" => :sub,
+    "psub" => :psub,
+    "ssub" => :ssub,
+    "multi" => :multi,
+    "qbuf" => :qbuf,
+    "qbuf-free" => :qbuf_free,
+    "argv-mem" => :argv_mem,
+    "multi-mem" => :multi_mem,
+    "obl" => :obl,
+    "oll" => :oll,
+    "omem" => :omem,
+    "tot-mem" => :tot_mem,
+    "redir" => :redir,
+    "resp" => :resp,
+    "io-thread" => :io_thread
+  }
+
+  @string_client_fields %{
+    "addr" => :addr,
+    "laddr" => :laddr,
+    "name" => :name,
+    "events" => :events,
+    "cmd" => :cmd,
+    "user" => :user,
+    "lib-name" => :lib_name,
+    "lib-ver" => :lib_ver
+  }
+
+  @typed_mode :typed
+  @raw_mode :raw
+
+  @doc false
+  @spec decode({:ok, term()} | {:error, term()}, [term()], keyword()) ::
+          {:ok, term()} | {:error, term()}
+  def decode(result, command, opts) do
+    case Keyword.get(opts, :response, @raw_mode) do
+      @raw_mode ->
+        result
+
+      @typed_mode ->
+        decode_typed(result, command)
+
+      mode ->
+        response_error(command, nil, {:invalid_response_mode, mode})
+    end
+  end
+
+  @doc false
+  @spec decode_many({:ok, [term()]} | {:error, term()}, [[term()]], keyword()) ::
+          {:ok, [term()]} | {:error, term()}
+  def decode_many(result, commands, opts) do
+    case Keyword.get(opts, :response, @raw_mode) do
+      @raw_mode ->
+        result
+
+      @typed_mode ->
+        decode_many_typed(result, commands)
+
+      mode ->
+        response_error(nil, nil, {:invalid_response_mode, mode})
+    end
+  end
+
+  @doc """
+  Parses one raw reply using its command.
+
+  Unknown commands return `{:ok, response}` unchanged. A malformed reply for a
+  supported command returns `{:error, %Redis.ResponseError{}}`.
+  """
+  @spec parse([term()], term()) :: {:ok, term()} | {:error, Redis.ResponseError.t()}
+  def parse(command, response) when is_list(command) do
+    case do_parse(command, response) do
+      {:ok, parsed} -> {:ok, parsed}
+      {:error, reason} -> response_error(command, response, reason)
+    end
+  end
+
+  defp decode_typed({:ok, response}, command), do: parse(command, response)
+  defp decode_typed({:error, _reason} = error, _command), do: error
+
+  defp decode_many_typed({:error, _reason} = error, _commands), do: error
+
+  defp decode_many_typed({:ok, responses}, commands)
+       when is_list(responses) and length(responses) == length(commands) do
+    commands
+    |> Enum.zip(responses)
+    |> Enum.reduce_while({:ok, []}, fn
+      {_command, %Redis.Error{} = error}, {:ok, parsed} ->
+        {:cont, {:ok, [error | parsed]}}
+
+      {command, response}, {:ok, parsed} ->
+        case parse(command, response) do
+          {:ok, value} -> {:cont, {:ok, [value | parsed]}}
+          {:error, _reason} = error -> {:halt, error}
+        end
+    end)
+    |> case do
+      {:ok, parsed} -> {:ok, Enum.reverse(parsed)}
+      error -> error
+    end
+  end
+
+  defp decode_many_typed({:ok, responses}, commands) do
+    response_error(commands, responses, :response_count_mismatch)
+  end
+
+  defp do_parse([command | rest] = full_command, response) when is_binary(command) do
+    command
+    |> String.upcase()
+    |> parse_command(rest, full_command, response)
+  end
+
+  defp do_parse(_command, response), do: {:ok, response}
+
+  defp parse_command(command, _rest, _full_command, response) when command in @map_commands,
+    do: parse_map(response)
+
+  defp parse_command("CONFIG", rest, _full_command, response) do
+    if subcommand(rest) == "GET", do: parse_map(response), else: {:ok, response}
+  end
+
+  defp parse_command(command, _rest, _full_command, response) when command in @set_commands,
+    do: parse_set(response)
+
+  defp parse_command("INFO", _rest, _full_command, response), do: parse_info(response)
+
+  defp parse_command("CLIENT", rest, _full_command, response) do
+    case subcommand(rest) do
+      "LIST" -> parse_client_list(response)
+      "INFO" -> parse_client_info(response)
+      _other -> {:ok, response}
+    end
+  end
+
+  defp parse_command(command, _rest, _full_command, response) when command in @range_commands,
+    do: parse_entries(response)
+
+  defp parse_command(command, _rest, full_command, response) when command in @read_commands,
+    do: parse_streams(full_command, response)
+
+  defp parse_command(_command, _rest, _full_command, response), do: {:ok, response}
+
+  defp subcommand([subcommand | _]) when is_binary(subcommand), do: String.upcase(subcommand)
+  defp subcommand(_), do: nil
+
+  defp parse_map(response) when is_map(response), do: {:ok, response}
+
+  defp parse_map(response) when is_list(response) do
+    if rem(length(response), 2) == 0 do
+      {:ok, response |> Enum.chunk_every(2) |> Map.new(fn [key, value] -> {key, value} end)}
+    else
+      {:error, :odd_map_response}
+    end
+  end
+
+  defp parse_map(_response), do: {:error, :expected_map_or_flat_list}
+
+  defp parse_set(%MapSet{} = response), do: {:ok, response}
+  defp parse_set(response) when is_list(response), do: {:ok, MapSet.new(response)}
+  defp parse_set(_response), do: {:error, :expected_set_or_list}
+
+  defp parse_info(response) when is_binary(response) do
+    info =
+      response
+      |> String.split(~r/\r?\n/, trim: true)
+      |> Enum.reject(&String.starts_with?(&1, "#"))
+      |> Enum.reduce(%{}, fn line, info ->
+        case String.split(line, ":", parts: 2) do
+          [key, value] -> Map.put(info, key, value)
+          _malformed -> info
+        end
+      end)
+
+    {:ok, info}
+  end
+
+  defp parse_info(_response), do: {:error, :expected_info_string}
+
+  defp parse_client_list(response) when is_binary(response) do
+    response
+    |> String.split(~r/\r?\n/, trim: true)
+    |> Enum.reduce_while({:ok, []}, fn line, {:ok, clients} ->
+      case parse_client(line) do
+        {:ok, client} -> {:cont, {:ok, [client | clients]}}
+        {:error, _reason} = error -> {:halt, error}
+      end
+    end)
+    |> case do
+      {:ok, clients} -> {:ok, Enum.reverse(clients)}
+      error -> error
+    end
+  end
+
+  defp parse_client_list(_response), do: {:error, :expected_client_list_string}
+
+  defp parse_client_info(response) when is_binary(response),
+    do: parse_client(String.trim(response))
+
+  defp parse_client_info(_response), do: {:error, :expected_client_info_string}
+
+  defp parse_client(""), do: {:error, :empty_client_record}
+
+  defp parse_client(line) do
+    attributes =
+      line
+      |> String.split(" ", trim: true)
+      |> Enum.reduce(%{}, fn token, attributes ->
+        case String.split(token, "=", parts: 2) do
+          [key, value] -> Map.put(attributes, key, value)
+          _malformed -> attributes
+        end
+      end)
+
+    client =
+      Enum.reduce(@string_client_fields, %Client{attributes: attributes}, fn
+        {wire_name, field}, client -> Map.put(client, field, attributes[wire_name])
+      end)
+
+    with {:ok, client} <- put_integer_client_fields(client, attributes) do
+      {:ok, %{client | flags: parse_flags(attributes["flags"])}}
+    end
+  end
+
+  defp put_integer_client_fields(client, attributes) do
+    Enum.reduce_while(@integer_client_fields, {:ok, client}, fn
+      {wire_name, field}, {:ok, client} ->
+        case parse_optional_integer(attributes[wire_name]) do
+          {:ok, value} -> {:cont, {:ok, Map.put(client, field, value)}}
+          :error -> {:halt, {:error, {:invalid_client_integer, wire_name}}}
+        end
+    end)
+  end
+
+  defp parse_optional_integer(nil), do: {:ok, nil}
+
+  defp parse_optional_integer(value) do
+    case Integer.parse(value) do
+      {integer, ""} -> {:ok, integer}
+      _invalid -> :error
+    end
+  end
+
+  defp parse_flags(nil), do: MapSet.new()
+  defp parse_flags(flags), do: flags |> String.graphemes() |> MapSet.new()
+
+  defp parse_entries(response) when is_list(response) do
+    response
+    |> Enum.reduce_while({:ok, []}, fn entry, {:ok, entries} ->
+      case parse_entry(entry) do
+        {:ok, parsed} -> {:cont, {:ok, [parsed | entries]}}
+        {:error, _reason} = error -> {:halt, error}
+      end
+    end)
+    |> case do
+      {:ok, entries} -> {:ok, Enum.reverse(entries)}
+      error -> error
+    end
+  end
+
+  defp parse_entries(_response), do: {:error, :expected_stream_entries}
+
+  defp parse_entry([id, nil]) when is_binary(id),
+    do: {:ok, %StreamEntry{id: id, fields: nil}}
+
+  defp parse_entry([id, fields]) when is_binary(id) do
+    case parse_map(fields) do
+      {:ok, fields} -> {:ok, %StreamEntry{id: id, fields: fields}}
+      {:error, reason} -> {:error, {:invalid_stream_fields, reason}}
+    end
+  end
+
+  defp parse_entry(_entry), do: {:error, :invalid_stream_entry}
+
+  defp parse_streams(_command, nil), do: {:ok, nil}
+
+  defp parse_streams(command, response) when is_map(response) do
+    requested_names = stream_names(command)
+    response_names = Map.keys(response)
+
+    names =
+      requested_names ++
+        (response_names
+         |> Enum.reject(&(&1 in requested_names))
+         |> Enum.sort())
+
+    names
+    |> Enum.reduce_while({:ok, []}, fn name, {:ok, streams} ->
+      case Map.fetch(response, name) do
+        {:ok, entries} -> add_stream(name, entries, streams)
+        :error -> {:cont, {:ok, streams}}
+      end
+    end)
+    |> reverse_streams()
+  end
+
+  defp parse_streams(_command, response) when is_list(response) do
+    response
+    |> Enum.reduce_while({:ok, []}, fn
+      [name, entries], {:ok, streams} when is_binary(name) ->
+        case parse_entries(entries) do
+          {:ok, entries} ->
+            {:cont, {:ok, [%Stream{name: name, entries: entries} | streams]}}
+
+          {:error, _reason} = error ->
+            {:halt, error}
+        end
+
+      _invalid, _acc ->
+        {:halt, {:error, :invalid_stream_response}}
+    end)
+    |> reverse_streams()
+  end
+
+  defp parse_streams(_command, _response), do: {:error, :expected_stream_response}
+
+  defp reverse_streams({:ok, streams}), do: {:ok, Enum.reverse(streams)}
+  defp reverse_streams(error), do: error
+
+  defp add_stream(name, entries, streams) do
+    case parse_entries(entries) do
+      {:ok, entries} ->
+        {:cont, {:ok, [%Stream{name: name, entries: entries} | streams]}}
+
+      {:error, _reason} = error ->
+        {:halt, error}
+    end
+  end
+
+  defp stream_names(command) do
+    case Enum.find_index(command, &(is_binary(&1) and String.upcase(&1) == "STREAMS")) do
+      nil ->
+        []
+
+      streams_index ->
+        stream_args = Enum.drop(command, streams_index + 1)
+        Enum.take(stream_args, div(length(stream_args), 2))
+    end
+  end
+
+  defp response_error(command, response, reason) do
+    {:error, %Redis.ResponseError{command: command, response: response, reason: reason}}
+  end
+end

--- a/lib/redis/sentinel/sentinel.ex
+++ b/lib/redis/sentinel/sentinel.ex
@@ -47,6 +47,9 @@ defmodule Redis.Sentinel do
       milliseconds for replica routing (default: 30_000; `nil` disables it)
     * `:name` - GenServer name registration
     * `:protocol` - `:resp3` or `:resp2` (default: `:resp3`)
+
+  Command, pipeline, and transaction calls accept `response: :typed`; see
+  `Redis.Response`.
   """
 
   use GenServer
@@ -55,6 +58,7 @@ defmodule Redis.Sentinel do
   alias Redis.Protocol.RESP2
   alias Redis.ReplicaSet
   alias Redis.ReplicaSet.Topology
+  alias Redis.Response
   alias Redis.Sentinel.Monitor
 
   require Logger
@@ -100,21 +104,30 @@ defmodule Redis.Sentinel do
           {:ok, term()} | {:error, term()}
   def command(sentinel, args, opts \\ []) do
     timeout = Keyword.get(opts, :timeout, 5_000)
-    GenServer.call(sentinel, {:command, args}, timeout)
+
+    sentinel
+    |> GenServer.call({:command, args}, timeout)
+    |> Response.decode(args, opts)
   end
 
   @spec pipeline(GenServer.server(), [[String.t()]], keyword()) ::
           {:ok, [term()]} | {:error, term()}
   def pipeline(sentinel, commands, opts \\ []) do
     timeout = Keyword.get(opts, :timeout, 5_000)
-    GenServer.call(sentinel, {:pipeline, commands}, timeout)
+
+    sentinel
+    |> GenServer.call({:pipeline, commands}, timeout)
+    |> Response.decode_many(commands, opts)
   end
 
   @spec transaction(GenServer.server(), [[String.t()]], keyword()) ::
           {:ok, [term()]} | {:error, term()}
   def transaction(sentinel, commands, opts \\ []) do
     timeout = Keyword.get(opts, :timeout, 5_000)
-    GenServer.call(sentinel, {:transaction, commands}, timeout)
+
+    sentinel
+    |> GenServer.call({:transaction, commands}, timeout)
+    |> Response.decode_many(commands, opts)
   end
 
   @doc "Returns info about the current connection."

--- a/test/integration/response_test.exs
+++ b/test/integration/response_test.exs
@@ -1,0 +1,92 @@
+defmodule Redis.ResponseIntegrationTest do
+  use ExUnit.Case, async: false
+
+  alias Redis.Connection
+  alias Redis.Response.{Client, Stream, StreamEntry}
+
+  setup do
+    {:ok, conn} = Connection.start_link(port: 6398)
+    {:ok, resp2} = Connection.start_link(port: 6398, protocol: :resp2)
+
+    Connection.command(conn, ["FLUSHDB"])
+
+    %{conn: conn, resp2: resp2}
+  end
+
+  test "raw remains the default and typed HGETALL is protocol-independent", %{
+    conn: conn,
+    resp2: resp2
+  } do
+    assert {:ok, 2} =
+             Connection.command(conn, ["HSET", "typed:hash", "name", "Ada", "role", "admin"])
+
+    assert {:ok, ["name", "Ada", "role", "admin"]} =
+             Connection.command(resp2, ["HGETALL", "typed:hash"])
+
+    expected = %{"name" => "Ada", "role" => "admin"}
+
+    assert {:ok, ^expected} =
+             Connection.command(resp2, ["HGETALL", "typed:hash"], response: :typed)
+
+    assert {:ok, ^expected} =
+             Connection.command(conn, ["HGETALL", "typed:hash"], response: :typed)
+  end
+
+  test "INFO and CLIENT LIST have structured typed replies", %{conn: conn} do
+    assert {:ok, %{"redis_version" => version}} =
+             Connection.command(conn, ["INFO", "server"], response: :typed)
+
+    assert is_binary(version)
+
+    assert {:ok, clients} =
+             Connection.command(conn, ["CLIENT", "LIST"], response: :typed)
+
+    assert Enum.all?(clients, &match?(%Client{}, &1))
+    assert Enum.any?(clients, &(&1.lib_name == "redis_client_ex"))
+  end
+
+  test "stream replies are normalized for ranges and reads", %{conn: conn} do
+    assert {:ok, id} =
+             Connection.command(conn, ["XADD", "typed:events", "*", "event", "created"])
+
+    assert {:ok, [%StreamEntry{id: ^id, fields: %{"event" => "created"}}]} =
+             Connection.command(
+               conn,
+               ["XRANGE", "typed:events", "-", "+"],
+               response: :typed
+             )
+
+    assert {:ok,
+            [
+              %Stream{
+                name: "typed:events",
+                entries: [%StreamEntry{id: ^id, fields: %{"event" => "created"}}]
+              }
+            ]} =
+             Connection.command(
+               conn,
+               ["XREAD", "STREAMS", "typed:events", "0"],
+               response: :typed
+             )
+  end
+
+  test "pipelines and top-level helpers parse each known reply", %{conn: conn} do
+    assert {:ok, ["OK", 1, %{"name" => "Ada"}]} =
+             Redis.pipeline_typed(conn, [
+               ["SET", "typed:key", "value"],
+               ["HSET", "typed:user", "name", "Ada"],
+               ["HGETALL", "typed:user"]
+             ])
+
+    assert {:ok, %MapSet{} = members} =
+             Redis.command_typed(conn, ["SMEMBERS", "typed:set"])
+
+    assert MapSet.size(members) == 0
+
+    assert {:ok, [1, %{"field" => "value"}]} =
+             Redis.transaction_typed(conn, [
+               ["HSET", "typed:transaction", "field", "value"],
+               ["HGETALL", "typed:transaction"]
+             ])
+  end
+end

--- a/test/unit/protocol/coerce_test.exs
+++ b/test/unit/protocol/coerce_test.exs
@@ -39,6 +39,11 @@ defmodule Redis.Protocol.CoerceTest do
       assert Coerce.coerce(nil, "GET") == nil
     end
 
+    test "stream entry lists are not mistaken for flat maps" do
+      entries = [["1-0", ["field", "value"]]]
+      assert Coerce.coerce(entries, "XRANGE") == entries
+    end
+
     test "non-list result passes through even for map commands" do
       assert Coerce.coerce(nil, "HGETALL") == nil
       assert Coerce.coerce("OK", "SMEMBERS") == "OK"

--- a/test/unit/response_test.exs
+++ b/test/unit/response_test.exs
@@ -1,0 +1,202 @@
+defmodule Redis.ResponseTest do
+  use ExUnit.Case, async: true
+
+  alias Redis.Response
+  alias Redis.Response.{Client, Stream, StreamEntry}
+
+  describe "parse/2 maps and sets" do
+    test "normalizes RESP2 and RESP3 HGETALL replies" do
+      assert {:ok, %{"name" => "Ada", "role" => "admin"}} =
+               Response.parse(["HGETALL", "user:1"], ["name", "Ada", "role", "admin"])
+
+      response = %{"name" => "Ada"}
+      assert {:ok, ^response} = Response.parse(["HGETALL", "user:1"], response)
+    end
+
+    test "normalizes CONFIG GET and set replies" do
+      assert {:ok, %{"maxmemory" => "0"}} =
+               Response.parse(["CONFIG", "GET", "maxmemory"], ["maxmemory", "0"])
+
+      assert {:ok, %MapSet{} = members} =
+               Response.parse(["SMEMBERS", "letters"], ["a", "b", "a"])
+
+      assert members == MapSet.new(["a", "b"])
+    end
+
+    test "reports malformed known replies" do
+      assert {:error, %Redis.ResponseError{reason: :odd_map_response}} =
+               Response.parse(["HGETALL", "user:1"], ["name"])
+    end
+
+    test "passes unknown command replies through" do
+      assert {:ok, "OK"} = Response.parse(["SET", "key", "value"], "OK")
+    end
+  end
+
+  describe "parse/2 INFO" do
+    test "returns a flat map and preserves values containing colons" do
+      info = """
+      # Server
+      redis_version:8.0.0
+      executable:/usr/local/bin/redis:server
+
+      # Clients
+      connected_clients:3
+      """
+
+      assert {:ok,
+              %{
+                "redis_version" => "8.0.0",
+                "executable" => "/usr/local/bin/redis:server",
+                "connected_clients" => "3"
+              }} = Response.parse(["INFO"], info)
+    end
+  end
+
+  describe "parse/2 CLIENT" do
+    test "CLIENT LIST returns structs while retaining every raw attribute" do
+      response =
+        "id=42 addr=127.0.0.1:5000 laddr=127.0.0.1:6379 fd=8 name=worker " <>
+          "age=12 idle=3 flags=N db=2 sub=1 psub=0 ssub=0 multi=-1 " <>
+          "cmd=get user=default redir=-1 resp=3 lib-name=redis_client_ex lib-ver=0.7.1"
+
+      assert {:ok,
+              [
+                %Client{
+                  id: 42,
+                  addr: "127.0.0.1:5000",
+                  name: "worker",
+                  age: 12,
+                  idle: 3,
+                  db: 2,
+                  sub: 1,
+                  cmd: "get",
+                  user: "default",
+                  resp: 3,
+                  lib_name: "redis_client_ex",
+                  lib_ver: "0.7.1",
+                  flags: flags,
+                  attributes: attributes
+                }
+              ]} = Response.parse(["CLIENT", "LIST"], response)
+
+      assert flags == MapSet.new(["N"])
+      assert attributes["laddr"] == "127.0.0.1:6379"
+    end
+
+    test "CLIENT INFO returns one struct" do
+      assert {:ok, %Client{id: 7, name: "me"}} =
+               Response.parse(["CLIENT", "INFO"], "id=7 name=me flags=N")
+    end
+  end
+
+  describe "parse/2 streams" do
+    test "XRANGE returns structured entries" do
+      response = [
+        ["1-0", ["event", "created", "actor", "ada"]],
+        ["2-0", %{"event" => "updated"}]
+      ]
+
+      assert {:ok,
+              [
+                %StreamEntry{
+                  id: "1-0",
+                  fields: %{"event" => "created", "actor" => "ada"}
+                },
+                %StreamEntry{id: "2-0", fields: %{"event" => "updated"}}
+              ]} = Response.parse(["XRANGE", "events", "-", "+"], response)
+    end
+
+    test "XREAD normalizes RESP2 replies" do
+      response = [
+        ["events", [["1-0", ["event", "created"]]]],
+        ["audit", [["2-0", ["actor", "ada"]]]]
+      ]
+
+      assert {:ok,
+              [
+                %Stream{
+                  name: "events",
+                  entries: [%StreamEntry{id: "1-0", fields: %{"event" => "created"}}]
+                },
+                %Stream{
+                  name: "audit",
+                  entries: [%StreamEntry{id: "2-0", fields: %{"actor" => "ada"}}]
+                }
+              ]} =
+               Response.parse(
+                 ["XREAD", "STREAMS", "events", "audit", "0", "0"],
+                 response
+               )
+    end
+
+    test "XREAD preserves command stream order for RESP3 maps" do
+      response = %{
+        "audit" => [["2-0", ["actor", "ada"]]],
+        "events" => [["1-0", ["event", "created"]]]
+      }
+
+      assert {:ok, [%Stream{name: "events"}, %Stream{name: "audit"}]} =
+               Response.parse(
+                 ["XREAD", "STREAMS", "events", "audit", "0", "0"],
+                 response
+               )
+    end
+
+    test "XREAD preserves nil when no streams are ready" do
+      assert {:ok, nil} = Response.parse(["XREAD", "STREAMS", "events", "$"], nil)
+    end
+
+    test "XREADGROUP represents deleted pending entries with nil fields" do
+      assert {:ok,
+              [
+                %Stream{
+                  name: "events",
+                  entries: [%StreamEntry{id: "1-0", fields: nil}]
+                }
+              ]} =
+               Response.parse(
+                 ["XREADGROUP", "GROUP", "workers", "one", "STREAMS", "events", "0"],
+                 [["events", [["1-0", nil]]]]
+               )
+    end
+  end
+
+  describe "decode/3 and decode_many/3" do
+    test "raw mode is the default" do
+      raw = {:ok, ["name", "Ada"]}
+      assert ^raw = Response.decode(raw, ["HGETALL", "user:1"], [])
+    end
+
+    test "typed mode parses one reply" do
+      assert {:ok, %{"name" => "Ada"}} =
+               Response.decode(
+                 {:ok, ["name", "Ada"]},
+                 ["HGETALL", "user:1"],
+                 response: :typed
+               )
+    end
+
+    test "typed pipelines preserve command errors and parse successful replies" do
+      error = %Redis.Error{message: "ERR failure"}
+
+      assert {:ok, [%{"name" => "Ada"}, ^error, "OK"]} =
+               Response.decode_many(
+                 {:ok, [["name", "Ada"], error, "OK"]},
+                 [
+                   ["HGETALL", "user:1"],
+                   ["HGETALL", "missing"],
+                   ["SET", "key", "value"]
+                 ],
+                 response: :typed
+               )
+    end
+
+    test "invalid response modes return a descriptive error" do
+      assert {:error, %Redis.ResponseError{reason: {:invalid_response_mode, :automatic}} = error} =
+               Response.decode({:ok, "PONG"}, ["PING"], response: :automatic)
+
+      assert Exception.message(error) =~ "expected :raw or :typed"
+    end
+  end
+end


### PR DESCRIPTION
Closes #113.

## Summary
- add backward-compatible typed response parsing behind response: :typed
- normalize hashes, sets, INFO, CLIENT records, and stream replies across RESP2 and RESP3
- apply typed parsing consistently to connections, pools/resilience, clusters, Sentinel, and replica-set routing
- add typed command, pipeline, and transaction helpers plus public response structs and docs
- preserve raw replies by default and pass unsupported commands through unchanged

## Verification
- full suite: 1192 passed (13 properties, 1179 tests), 85 excluded
- final unit and focused integration suite: 904 passed
- mix compile --warnings-as-errors
- mix format --check-formatted
- mix credo --strict
- mix dialyzer
- mix docs

BEGIN_COMMIT_OVERRIDE
feat: add opt-in typed Redis responses
END_COMMIT_OVERRIDE
