### PR TITLE
Add opt-in command auto-pipelining

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,30 @@ Typed mode parses `HGETALL`, `CONFIG GET`, set operations, `INFO`,
 commands pass through unchanged, including within mixed pipelines. See
 `Redis.Response` for the complete return types.
 
+## Auto-Pipelining
+
+Opt in to automatic batching when many processes issue commands concurrently:
+
+```elixir
+{:ok, conn} = Redis.start_link(
+  auto_pipeline: true,
+  auto_pipeline_window: 1,       # collect commands for up to 1 ms
+  auto_pipeline_max_size: 1_000  # or flush when this size is reached
+)
+
+1..100
+|> Task.async_stream(fn i ->
+  Redis.command(conn, ["SET", "key:#{i}", to_string(i)])
+end, max_concurrency: 100)
+|> Stream.run()
+```
+
+Each caller still receives only its own reply, with its own hooks, telemetry,
+timeout, and typed-response handling. Explicit pipelines, transactions, and
+no-reply operations act as ordering barriers and flush queued commands first.
+The feature is disabled by default. `Redis.Connection.Pool` passes the options
+to every physical connection, so each connection builds independent batches.
+
 ## Command Builders
 
 Pure functions that return command lists. Use them with any connection type.
@@ -444,6 +468,7 @@ Redis.Resilience.command(conn, ["GET", "key"])
 - **Phoenix.PubSub adapter** for cross-node broadcasting (optional dep)
 - **Streams Consumer** with consumer groups, auto-ack, and pending message recovery
 - **WATCH transactions** with automatic retry on conflict
+- **Auto-pipelining** for concurrent callers, with per-connection batching
 - **JSON documents** with map-based CRUD, nested paths, atomic operations (Redis Stack)
 - **Search** with Elixir filter expressions, auto-coercion, parsed results (Redis Stack)
 - **Plug session store** with configurable TTL

--- a/lib/redis.ex
+++ b/lib/redis.ex
@@ -45,6 +45,15 @@ defmodule Redis do
       {:ok, entries} =
         Redis.command_typed(conn, ["XRANGE", "events", "-", "+"])
 
+  ## Auto-Pipelining
+
+      {:ok, conn} =
+        Redis.start_link(
+          auto_pipeline: true,
+          auto_pipeline_window: 1,
+          auto_pipeline_max_size: 1_000
+        )
+
   ## Transactions
 
       {:ok, [1, 2, 3]} = Redis.transaction(conn, [

--- a/lib/redis/connection/connection.ex
+++ b/lib/redis/connection/connection.ex
@@ -30,6 +30,12 @@ defmodule Redis.Connection do
     * `:exit_on_disconnection` - exit instead of reconnecting (default: false)
     * `:hibernate_after` - idle ms before hibernation (default: nil)
     * `:hooks` - list of `Redis.Hook` modules for command middleware (default: [])
+    * `:auto_pipeline` - batch concurrent commands into one socket write
+      (default: false)
+    * `:auto_pipeline_window` - time in milliseconds to collect a batch
+      (default: 1)
+    * `:auto_pipeline_max_size` - flush a batch when it reaches this many
+      commands (default: 1_000)
 
   Command, pipeline, and transaction calls also accept `response: :typed` to
   opt into the structured values documented by `Redis.Response`. Raw RESP
@@ -64,12 +70,18 @@ defmodule Redis.Connection do
     :timeout,
     :push_receiver,
     :credential_provider,
+    :auto_pipeline_timer,
     protocol: :resp3,
     state: :disconnected,
     exit_on_disconnection: false,
     buffer: <<>>,
     callers: :queue.new(),
-    hooks: []
+    hooks: [],
+    auto_pipeline: false,
+    auto_pipeline_window: 1,
+    auto_pipeline_max_size: 1_000,
+    auto_pipeline_batch: [],
+    auto_pipeline_size: 0
   ]
 
   @behaviour Redis.Connection.Behaviour
@@ -100,16 +112,18 @@ defmodule Redis.Connection do
   end
 
   def start_link(opts) when is_list(opts) do
-    {name, opts} = Keyword.pop(opts, :name)
-    {hibernate_after, opts} = Keyword.pop(opts, :hibernate_after)
+    with :ok <- validate_auto_pipeline_options(opts) do
+      {name, opts} = Keyword.pop(opts, :name)
+      {hibernate_after, opts} = Keyword.pop(opts, :hibernate_after)
 
-    gen_opts = []
-    gen_opts = if name, do: [{:name, name} | gen_opts], else: gen_opts
+      gen_opts = []
+      gen_opts = if name, do: [{:name, name} | gen_opts], else: gen_opts
 
-    gen_opts =
-      if hibernate_after, do: [{:hibernate_after, hibernate_after} | gen_opts], else: gen_opts
+      gen_opts =
+        if hibernate_after, do: [{:hibernate_after, hibernate_after} | gen_opts], else: gen_opts
 
-    GenServer.start_link(__MODULE__, opts, gen_opts)
+      GenServer.start_link(__MODULE__, opts, gen_opts)
+    end
   end
 
   def start_link, do: start_link([])
@@ -291,7 +305,10 @@ defmodule Redis.Connection do
       exit_on_disconnection: Keyword.get(opts, :exit_on_disconnection, false),
       push_receiver: Keyword.get(opts, :push_receiver),
       credential_provider: credential_provider,
-      hooks: Keyword.get(opts, :hooks, [])
+      hooks: Keyword.get(opts, :hooks, []),
+      auto_pipeline: Keyword.get(opts, :auto_pipeline, false),
+      auto_pipeline_window: Keyword.get(opts, :auto_pipeline_window, 1),
+      auto_pipeline_max_size: Keyword.get(opts, :auto_pipeline_max_size, 1_000)
     }
 
     sync = Keyword.get(opts, :sync_connect, true)
@@ -321,6 +338,27 @@ defmodule Redis.Connection do
     handle_call({:transaction, commands}, from, state)
   end
 
+  def handle_call(
+        {operation, _payload} = message,
+        from,
+        %{
+          state: :ready,
+          auto_pipeline_size: size
+        } = state
+      )
+      when operation in [:pipeline, :transaction, :noreply_command, :noreply_pipeline] and
+             size > 0 do
+    case flush_auto_pipeline(state, :barrier) do
+      {:ok, state} ->
+        handle_call(message, from, state)
+
+      {:error, reason, state} ->
+        state
+        |> fail_auto_pipeline(reason)
+        |> send_error_reply(reason)
+    end
+  end
+
   def handle_call({:command, args}, from, %{state: :ready} = state) do
     ctx = hook_context(state)
 
@@ -329,18 +367,8 @@ defmodule Redis.Connection do
         {:reply, err, state}
 
       {:ok, args} ->
-        data = encode(state.protocol, args)
         telemetry = telemetry_start(state, [args])
-
-        case send_data(state, data) do
-          :ok ->
-            callers = :queue.in({from, :single, {args, ctx, telemetry}}, state.callers)
-            {:noreply, %{state | callers: callers}}
-
-          {:error, reason} ->
-            telemetry_exception(telemetry, reason)
-            send_error_reply(state, reason)
-        end
+        dispatch_command(state, from, args, ctx, telemetry)
     end
   end
 
@@ -459,6 +487,7 @@ defmodule Redis.Connection do
   def handle_info({closed, socket}, %{socket: socket} = state)
       when closed in [:tcp_closed, :ssl_closed] do
     Logger.warning("Redis: connection closed")
+    state = fail_auto_pipeline(state, :closed)
     state = fail_pending_callers(state, :closed)
     telemetry_disconnect(state, :closed)
 
@@ -472,6 +501,7 @@ defmodule Redis.Connection do
   def handle_info({error, socket, reason}, %{socket: socket} = state)
       when error in [:tcp_error, :ssl_error] do
     Logger.warning("Redis: connection error: #{inspect(reason)}")
+    state = fail_auto_pipeline(state, reason)
     state = fail_pending_callers(state, reason)
     telemetry_disconnect(state, reason)
 
@@ -494,6 +524,20 @@ defmodule Redis.Connection do
         {:noreply, schedule_reconnect(state)}
     end
   end
+
+  def handle_info(
+        {:flush_auto_pipeline, token},
+        %{
+          auto_pipeline_timer: {_timer, token}
+        } = state
+      ) do
+    case flush_auto_pipeline(state, :window) do
+      {:ok, state} -> {:noreply, state}
+      {:error, reason, state} -> handle_auto_pipeline_error(state, reason)
+    end
+  end
+
+  def handle_info({:flush_auto_pipeline, _stale_token}, state), do: {:noreply, state}
 
   def handle_info({kind, _stale_socket, _data}, state)
       when kind in [:tcp, :ssl, :tcp_error, :ssl_error],
@@ -947,6 +991,126 @@ defmodule Redis.Connection do
   end
 
   # -------------------------------------------------------------------
+  # Auto-pipelining
+  # -------------------------------------------------------------------
+
+  defp dispatch_command(%{auto_pipeline: true} = state, from, args, ctx, telemetry) do
+    enqueue_auto_pipeline(state, from, args, ctx, telemetry)
+  end
+
+  defp dispatch_command(state, from, args, ctx, telemetry) do
+    data = encode(state.protocol, args)
+
+    case send_data(state, data) do
+      :ok ->
+        callers = :queue.in({from, :single, {args, ctx, telemetry}}, state.callers)
+        {:noreply, %{state | callers: callers}}
+
+      {:error, reason} ->
+        telemetry_exception(telemetry, reason)
+        send_error_reply(state, reason)
+    end
+  end
+
+  defp enqueue_auto_pipeline(state, from, args, ctx, telemetry) do
+    state =
+      state
+      |> ensure_auto_pipeline_timer()
+      |> Map.update!(:auto_pipeline_batch, &[{from, args, ctx, telemetry} | &1])
+      |> Map.update!(:auto_pipeline_size, &(&1 + 1))
+
+    if state.auto_pipeline_size >= state.auto_pipeline_max_size do
+      case flush_auto_pipeline(state, :max_size) do
+        {:ok, state} -> {:noreply, state}
+        {:error, reason, state} -> handle_auto_pipeline_error(state, reason)
+      end
+    else
+      {:noreply, state}
+    end
+  end
+
+  defp ensure_auto_pipeline_timer(%{auto_pipeline_timer: nil} = state) do
+    token = make_ref()
+
+    timer =
+      Process.send_after(
+        self(),
+        {:flush_auto_pipeline, token},
+        state.auto_pipeline_window
+      )
+
+    %{state | auto_pipeline_timer: {timer, token}}
+  end
+
+  defp ensure_auto_pipeline_timer(state), do: state
+
+  defp flush_auto_pipeline(%{auto_pipeline_size: 0} = state, _reason), do: {:ok, state}
+
+  defp flush_auto_pipeline(state, reason) do
+    batch = Enum.reverse(state.auto_pipeline_batch)
+    commands = Enum.map(batch, fn {_from, args, _ctx, _telemetry} -> args end)
+    data = encode_pipeline(state.protocol, commands)
+
+    case send_data(state, data) do
+      :ok ->
+        callers =
+          Enum.reduce(batch, state.callers, fn {from, args, ctx, telemetry}, callers ->
+            :queue.in({from, :single, {args, ctx, telemetry}}, callers)
+          end)
+
+        telemetry_auto_pipeline_flush(state, length(batch), reason)
+        {:ok, %{reset_auto_pipeline(state) | callers: callers}}
+
+      {:error, send_reason} ->
+        {:error, send_reason, state}
+    end
+  end
+
+  defp reset_auto_pipeline(%{auto_pipeline_timer: nil} = state) do
+    %{state | auto_pipeline_batch: [], auto_pipeline_size: 0}
+  end
+
+  defp reset_auto_pipeline(%{auto_pipeline_timer: {timer, _token}} = state) do
+    Process.cancel_timer(timer)
+
+    %{
+      state
+      | auto_pipeline_batch: [],
+        auto_pipeline_size: 0,
+        auto_pipeline_timer: nil
+    }
+  end
+
+  defp fail_auto_pipeline(%{auto_pipeline_size: 0} = state, _reason),
+    do: reset_auto_pipeline(state)
+
+  defp fail_auto_pipeline(state, reason) do
+    error = {:error, %Redis.ConnectionError{reason: reason}}
+
+    state.auto_pipeline_batch
+    |> Enum.reverse()
+    |> Enum.each(fn {from, _args, _ctx, telemetry} ->
+      telemetry_exception(telemetry, reason)
+      GenServer.reply(from, error)
+    end)
+
+    reset_auto_pipeline(state)
+  end
+
+  defp handle_auto_pipeline_error(state, reason) do
+    state = fail_auto_pipeline(state, reason)
+    state = fail_pending_callers(state, reason)
+    telemetry_disconnect(state, reason)
+    state = handle_disconnect(state)
+
+    if state.exit_on_disconnection do
+      {:stop, {:connection_error, reason}, state}
+    else
+      {:noreply, schedule_reconnect(state)}
+    end
+  end
+
+  # -------------------------------------------------------------------
   # Reconnection
   # -------------------------------------------------------------------
 
@@ -960,6 +1124,7 @@ defmodule Redis.Connection do
 
   defp send_error_reply(state, reason) do
     error = {:error, %Redis.ConnectionError{reason: reason}}
+    state = fail_auto_pipeline(state, reason)
     state = fail_pending_callers(state, reason)
     telemetry_disconnect(state, reason)
     state = handle_disconnect(state)
@@ -1055,6 +1220,34 @@ defmodule Redis.Connection do
       %{},
       Map.put(connection_metadata(state), :reason, reason)
     )
+  end
+
+  defp telemetry_auto_pipeline_flush(state, batch_size, reason) do
+    Redis.Telemetry.execute(
+      [:redis_ex, :auto_pipeline, :flush],
+      %{batch_size: batch_size},
+      connection_metadata(state) |> Map.put(:reason, reason)
+    )
+  end
+
+  defp validate_auto_pipeline_options(opts) do
+    auto_pipeline = Keyword.get(opts, :auto_pipeline, false)
+    window = Keyword.get(opts, :auto_pipeline_window, 1)
+    max_size = Keyword.get(opts, :auto_pipeline_max_size, 1_000)
+
+    cond do
+      not is_boolean(auto_pipeline) ->
+        {:error, {:invalid_auto_pipeline, auto_pipeline}}
+
+      not is_integer(window) or window < 0 ->
+        {:error, {:invalid_auto_pipeline_window, window}}
+
+      not is_integer(max_size) or max_size <= 0 ->
+        {:error, {:invalid_auto_pipeline_max_size, max_size}}
+
+      true ->
+        :ok
+    end
   end
 
   defp connection_metadata(state) do

--- a/lib/redis/telemetry.ex
+++ b/lib/redis/telemetry.ex
@@ -24,6 +24,10 @@ defmodule Redis.Telemetry do
       * Measurements: `%{duration: native_time}`
       * Metadata: `%{commands: commands, kind: kind, reason: reason}`
 
+    * `[:redis_ex, :auto_pipeline, :flush]` - an automatic batch was sent
+      * Measurements: `%{batch_size: count}`
+      * Metadata: `%{host: host, port: port, reason: reason}`
+
   ## Usage
 
   Attach a handler:

--- a/test/integration/auto_pipeline_test.exs
+++ b/test/integration/auto_pipeline_test.exs
@@ -1,0 +1,198 @@
+defmodule Redis.AutoPipelineIntegrationTest do
+  use ExUnit.Case, async: false
+
+  alias Redis.Connection
+  alias Redis.Connection.Pool
+
+  @flush_event [:redis_ex, :auto_pipeline, :flush]
+
+  test "batches concurrent commands and returns each caller's own reply" do
+    {:ok, conn} =
+      Connection.start_link(
+        port: 6398,
+        auto_pipeline: true,
+        auto_pipeline_window: 20
+      )
+
+    assert {:ok, "OK"} = Connection.command(conn, ["SET", "auto:counter", "0"])
+    attach_flush_handler()
+
+    results =
+      1..20
+      |> Task.async_stream(
+        fn _index -> Connection.command(conn, ["INCR", "auto:counter"]) end,
+        max_concurrency: 20,
+        ordered: false,
+        timeout: 5_000
+      )
+      |> Enum.map(fn {:ok, {:ok, value}} -> value end)
+      |> Enum.sort()
+
+    assert results == Enum.to_list(1..20)
+    assert_receive {:auto_pipeline_flush, %{batch_size: 20}, %{reason: :window}}, 1_000
+  end
+
+  test "flushes immediately when the maximum batch size is reached" do
+    {:ok, setup_conn} = Connection.start_link(port: 6398)
+    assert {:ok, "OK"} = Connection.command(setup_conn, ["SET", "auto:max", "0"])
+
+    {:ok, conn} =
+      Connection.start_link(
+        port: 6398,
+        auto_pipeline: true,
+        auto_pipeline_window: 1_000,
+        auto_pipeline_max_size: 3
+      )
+
+    attach_flush_handler()
+
+    tasks =
+      for _index <- 1..3 do
+        Task.async(fn -> Connection.command(conn, ["INCR", "auto:max"]) end)
+      end
+
+    assert [1, 2, 3] =
+             tasks
+             |> Enum.map(&Task.await(&1, 2_000))
+             |> Enum.map(fn {:ok, value} -> value end)
+             |> Enum.sort()
+
+    assert_receive {:auto_pipeline_flush, %{batch_size: 3}, %{reason: :max_size}}, 500
+  end
+
+  test "flushes queued commands before an explicit pipeline" do
+    {:ok, setup_conn} = Connection.start_link(port: 6398)
+    assert {:ok, _deleted} = Connection.command(setup_conn, ["DEL", "auto:barrier"])
+
+    {:ok, conn} =
+      Connection.start_link(
+        port: 6398,
+        auto_pipeline: true,
+        auto_pipeline_window: 1_000
+      )
+
+    attach_flush_handler()
+    set_task = Task.async(fn -> Connection.command(conn, ["SET", "auto:barrier", "before"]) end)
+
+    eventually(fn -> :sys.get_state(conn).auto_pipeline_size == 1 end)
+
+    assert {:ok, ["before"]} =
+             Connection.pipeline(conn, [["GET", "auto:barrier"]])
+
+    assert {:ok, "OK"} = Task.await(set_task, 1_000)
+    assert_receive {:auto_pipeline_flush, %{batch_size: 1}, %{reason: :barrier}}, 500
+  end
+
+  test "a single-connection pool batches on its physical connection" do
+    {:ok, pool} =
+      Pool.start_link(
+        pool_size: 1,
+        port: 6398,
+        auto_pipeline: true,
+        auto_pipeline_window: 20
+      )
+
+    assert {:ok, "OK"} = Pool.command(pool, ["SET", "auto:pool", "0"])
+    attach_flush_handler()
+
+    results =
+      1..10
+      |> Task.async_stream(
+        fn _index -> Pool.command(pool, ["INCR", "auto:pool"]) end,
+        max_concurrency: 10,
+        ordered: false,
+        timeout: 5_000
+      )
+      |> Enum.map(fn {:ok, {:ok, value}} -> value end)
+      |> Enum.sort()
+
+    assert results == Enum.to_list(1..10)
+    assert_receive {:auto_pipeline_flush, %{batch_size: 10}, %{reason: :window}}, 1_000
+  end
+
+  test "typed response parsing remains transparent for batched callers" do
+    {:ok, setup_conn} = Connection.start_link(port: 6398)
+
+    assert {:ok, 2} =
+             Connection.command(
+               setup_conn,
+               ["HSET", "auto:typed", "name", "Ada", "role", "admin"]
+             )
+
+    {:ok, conn} =
+      Connection.start_link(
+        port: 6398,
+        protocol: :resp2,
+        auto_pipeline: true,
+        auto_pipeline_window: 20
+      )
+
+    tasks =
+      for _index <- 1..2 do
+        Task.async(fn ->
+          Connection.command(conn, ["HGETALL", "auto:typed"], response: :typed)
+        end)
+      end
+
+    assert [{:ok, expected}, {:ok, expected}] =
+             Enum.map(tasks, &Task.await(&1, 1_000))
+
+    assert expected == %{"name" => "Ada", "role" => "admin"}
+  end
+
+  test "pending unsent callers receive an error when the socket closes" do
+    {:ok, conn} =
+      Connection.start_link(
+        port: 6398,
+        client_name: "auto_pipeline_disconnect",
+        auto_pipeline: true,
+        auto_pipeline_window: 1_000,
+        backoff_initial: 60_000
+      )
+
+    {:ok, admin} = Connection.start_link(port: 6398)
+
+    assert {:ok, clients} =
+             Connection.command(admin, ["CLIENT", "LIST"], response: :typed)
+
+    client = Enum.find(clients, &(&1.name == "auto_pipeline_disconnect"))
+    assert client
+
+    pending = Task.async(fn -> Connection.command(conn, ["PING"], timeout: 2_000) end)
+    eventually(fn -> :sys.get_state(conn).auto_pipeline_size == 1 end)
+
+    assert {:ok, 1} =
+             Connection.command(admin, ["CLIENT", "KILL", "ID", to_string(client.id)])
+
+    assert {:error, %Redis.ConnectionError{reason: :closed}} =
+             Task.await(pending, 1_000)
+  end
+
+  defp attach_flush_handler do
+    handler_id = "auto-pipeline-test-#{System.unique_integer([:positive])}"
+    test_pid = self()
+
+    :telemetry.attach(
+      handler_id,
+      @flush_event,
+      fn _event, measurements, metadata, pid ->
+        send(pid, {:auto_pipeline_flush, measurements, metadata})
+      end,
+      test_pid
+    )
+
+    on_exit(fn -> :telemetry.detach(handler_id) end)
+  end
+
+  defp eventually(fun, attempts \\ 100)
+  defp eventually(fun, 0), do: assert(fun.())
+
+  defp eventually(fun, attempts) do
+    if fun.() do
+      :ok
+    else
+      Process.sleep(5)
+      eventually(fun, attempts - 1)
+    end
+  end
+end

--- a/test/integration/hook_test.exs
+++ b/test/integration/hook_test.exs
@@ -130,6 +130,32 @@ defmodule Redis.Integration.HookTest do
       Redis.Connection.stop(conn)
       CountingHook.cleanup()
     end
+
+    test "auto-pipelined commands retain per-command hooks" do
+      CountingHook.reset()
+
+      {:ok, conn} =
+        Redis.Connection.start_link(
+          port: 6398,
+          hooks: [CountingHook],
+          auto_pipeline: true,
+          auto_pipeline_window: 20
+        )
+
+      tasks =
+        for _index <- 1..3 do
+          Task.async(fn -> Redis.Connection.command(conn, ["PING"]) end)
+        end
+
+      assert Enum.all?(tasks, &match?({:ok, "PONG"}, Task.await(&1, 1_000)))
+      assert CountingHook.count(:before_command) == 3
+      assert CountingHook.count(:after_command) == 3
+      assert CountingHook.count(:before_pipeline) == 0
+      assert CountingHook.count(:after_pipeline) == 0
+
+      Redis.Connection.stop(conn)
+      CountingHook.cleanup()
+    end
   end
 
   describe "counting hooks on pipelines" do

--- a/test/unit/connection_auto_pipeline_test.exs
+++ b/test/unit/connection_auto_pipeline_test.exs
@@ -1,0 +1,26 @@
+defmodule Redis.Connection.AutoPipelineOptionsTest do
+  use ExUnit.Case, async: true
+
+  alias Redis.Connection
+
+  test "rejects a non-boolean auto_pipeline option" do
+    assert {:error, {:invalid_auto_pipeline, :yes}} =
+             Connection.start_link(auto_pipeline: :yes)
+  end
+
+  test "rejects a negative or non-integer batch window" do
+    assert {:error, {:invalid_auto_pipeline_window, -1}} =
+             Connection.start_link(auto_pipeline_window: -1)
+
+    assert {:error, {:invalid_auto_pipeline_window, 1.5}} =
+             Connection.start_link(auto_pipeline_window: 1.5)
+  end
+
+  test "rejects a non-positive maximum batch size" do
+    assert {:error, {:invalid_auto_pipeline_max_size, 0}} =
+             Connection.start_link(auto_pipeline_max_size: 0)
+
+    assert {:error, {:invalid_auto_pipeline_max_size, -10}} =
+             Connection.start_link(auto_pipeline_max_size: -10)
+  end
+end


### PR DESCRIPTION
Closes #112.

## Summary
- add opt-in per-connection batching for concurrently issued commands
- configure the collection window and maximum batch size
- preserve individual replies, command hooks, telemetry spans, timeouts, and typed-response parsing
- flush queued commands before explicit pipelines, transactions, and no-reply operations to preserve ordering
- fail both sent and unsent callers on socket errors and reconnect normally
- apply batching independently to each physical connection in a connection pool
- emit auto-pipeline flush telemetry with batch size and flush reason

## Verification
- full suite: 1204 passed (13 properties, 1191 tests), 85 excluded
- concurrent window and max-size flush coverage
- explicit ordering barrier coverage
- connection-pool, hook, RESP2 typed-response, and disconnect coverage
- mix compile --warnings-as-errors
- mix format --check-formatted
- mix credo --strict
- mix dialyzer
- mix docs

BEGIN_COMMIT_OVERRIDE
feat: add opt-in command auto-pipelining
END_COMMIT_OVERRIDE
