### PR TITLE
Add XREAD cluster routing regressions

### DIFF
--- a/test/integration/cluster_test.exs
+++ b/test/integration/cluster_test.exs
@@ -116,6 +116,32 @@ defmodule Redis.ClusterTest do
       end
     end
 
+    test "option-bearing XREAD routes by stream key on every master", %{cluster: cluster} do
+      streams = ["events:{06S}set", "events:{6eo}set", "events:{68H}set"]
+
+      for stream <- streams do
+        assert {:ok, _id} =
+                 Cluster.command(cluster, ["XADD", stream, "*", "event", "created"])
+
+        command = ["XREAD", "COUNT", "1", "STREAMS", stream, "0-0"]
+
+        assert {:ok, response} = Cluster.command(cluster, command)
+        assert response != nil
+      end
+
+      assert {:error, :cross_slot} =
+               Cluster.command(cluster, [
+                 "XREAD",
+                 "COUNT",
+                 "1",
+                 "STREAMS",
+                 Enum.at(streams, 0),
+                 Enum.at(streams, 1),
+                 "0-0",
+                 "0-0"
+               ])
+    end
+
     test "INCR across cluster", %{cluster: cluster} do
       assert {:ok, 1} = Cluster.command(cluster, ["INCR", "ctr:a"])
       assert {:ok, 2} = Cluster.command(cluster, ["INCR", "ctr:a"])

--- a/test/unit/router_test.exs
+++ b/test/unit/router_test.exs
@@ -76,6 +76,41 @@ defmodule Redis.Cluster.RouterTest do
              ]) == ["stream:a"]
     end
 
+    test "routes option-bearing stream reads by keys after STREAMS" do
+      stream = "events:{6eo}set"
+
+      xread = [
+        "XREAD",
+        "COUNT",
+        "1",
+        "BLOCK",
+        "10",
+        "STREAMS",
+        stream,
+        "0-0"
+      ]
+
+      xreadgroup = [
+        "XREADGROUP",
+        "GROUP",
+        "workers",
+        "one",
+        "COUNT",
+        "1",
+        "BLOCK",
+        "10",
+        "NOACK",
+        "STREAMS",
+        stream,
+        ">"
+      ]
+
+      assert Router.key_from_command(xread) == stream
+      assert Router.key_from_command(xreadgroup) == stream
+      assert Router.slot_for_command(xread) == {:ok, Router.slot(stream)}
+      refute Router.slot(stream) == Router.slot("COUNT")
+    end
+
     test "recognizes key-less commands with arguments" do
       assert Router.keys_from_command(["SCAN", "0", "MATCH", "*"]) == []
       assert Router.keys_from_command(["CLIENT", "SETNAME", "app"]) == []
@@ -91,6 +126,18 @@ defmodule Redis.Cluster.RouterTest do
 
     test "rejects a multi-key command spanning slots" do
       assert {:error, :cross_slot} = Router.slot_for_command(["MGET", "key:a", "key:b"])
+
+      assert {:error, :cross_slot} =
+               Router.slot_for_command([
+                 "XREAD",
+                 "COUNT",
+                 "1",
+                 "STREAMS",
+                 "events:{06S}set",
+                 "events:{6eo}set",
+                 "0-0",
+                 "0-0"
+               ])
     end
 
     test "reports key-less commands" do


### PR DESCRIPTION
Closes #132.

The production router fix landed in #130 after the 0.7.1 release, but the downstream issue remained open and its exact scenario was not covered end to end.

## Coverage
- prove COUNT, BLOCK, GROUP, and NOACK tokens are not treated as stream keys
- prove the reported command routes by the stream slot rather than slot(COUNT)
- exercise the reported slot-0, slot-7827, and slot-13045 stream keys against a real three-master cluster
- verify multi-stream XREAD across slots returns cross_slot before dispatch

## Verification
- 41 focused router and live cluster tests passed
- mix format --check-formatted
- mix credo --strict

BEGIN_COMMIT_OVERRIDE
test: cover XREAD cluster routing regressions
END_COMMIT_OVERRIDE
