### PR TITLE
chore: prepare 0.8.0 release

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,11 +55,23 @@ version matrix; full integration tests run on a daily schedule.
 
 - One PR per issue/feature
 - Reference the issue with `Closes #N` in the PR body
-- Use [conventional commits](https://www.conventionalcommits.org/):
+- Use a [conventional commit](https://www.conventionalcommits.org/) PR title,
+  because the squash-merge title becomes the commit on `main`:
   `feat:`, `fix:`, `docs:`, `test:`, `chore:`, `refactor:`
 - Keep PRs focused -- separate unrelated changes into separate PRs
 - Add tests for new features
 - Update documentation for public API changes
+
+## Releases
+
+Release Please reads the conventional squash commits on `main` and opens a
+release PR that updates `CHANGELOG.md`, `mix.exs`, and the release manifest.
+Merging that generated PR creates the GitHub release and publishes the package
+to Hex.pm through `.github/workflows/release.yml`.
+
+Do not bump the version or create tags manually. For an explicitly selected
+version, use a `Release-As: x.y.z` footer on a conventional commit and let the
+generated release PR make the versioned file changes.
 
 ## Test Organization
 


### PR DESCRIPTION
## Summary

- document that conventional PR titles become squash commits on `main`
- document the Release Please and Hex.pm publication workflow
- carry the `Release-As: 0.8.0` marker in the commit so the existing automation opens the version/changelog PR
- add supported release-note overrides to merged PRs #130, #131, #133, #134, #135, and #136 so the generated changelog reflects the work since v0.7.1

## Why

The six squash merges since v0.7.1 used non-conventional titles. Release Please completed successfully but could not parse any of them, so it had no commits from which to create a release PR.

## Validation

- `mix format --check-formatted`
- `mix compile --warnings-as-errors`
- `mix credo --strict`
- `mix dialyzer`
- `mix docs --warnings-as-errors`
- `mix test` — 1,206 passed (13 properties, 1,193 tests), 85 excluded
- `git diff --check`